### PR TITLE
Phase 0: inline gotcha strip + progressive-disclosure lint (#525, #526)

### DIFF
--- a/app/Http/Controllers/EvalSuiteController.php
+++ b/app/Http/Controllers/EvalSuiteController.php
@@ -7,6 +7,7 @@ use App\Models\SkillEvalPrompt;
 use App\Models\SkillEvalRun;
 use App\Models\SkillEvalSuite;
 use App\Services\LLM\LLMProviderFactory;
+use App\Services\PromptLinter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -162,12 +163,10 @@ class EvalSuiteController extends Controller
     {
         $description = $skill->description ?? '';
         $summary = $skill->summary ?? '';
-        $name = $skill->name;
 
         $issues = [];
         $score = 100;
 
-        // Length checks
         if (strlen($description) < 20) {
             $issues[] = 'Description is too short — may not trigger when needed.';
             $score -= 30;
@@ -177,19 +176,15 @@ class EvalSuiteController extends Controller
             $score -= 10;
         }
 
-        // Vagueness checks
-        $vagueWords = ['stuff', 'things', 'various', 'general', 'misc'];
-        foreach ($vagueWords as $word) {
+        foreach (PromptLinter::VAGUE_DESCRIPTION_WORDS as $word) {
             if (stripos($description, $word) !== false) {
                 $issues[] = "Description contains vague word: \"{$word}\".";
                 $score -= 10;
             }
         }
 
-        // Missing actionable verb
-        $actionVerbs = ['generate', 'create', 'analyze', 'review', 'check', 'format', 'convert', 'summarize', 'explain', 'debug', 'test', 'deploy', 'automate', 'enforce'];
         $hasVerb = false;
-        foreach ($actionVerbs as $verb) {
+        foreach (PromptLinter::DESCRIPTION_ACTION_VERBS as $verb) {
             if (stripos($description, $verb) !== false) {
                 $hasVerb = true;
                 break;
@@ -200,7 +195,6 @@ class EvalSuiteController extends Controller
             $score -= 15;
         }
 
-        // Summary check
         if (empty($summary)) {
             $issues[] = 'No summary set — tier-1 progressive disclosure will fall back to description.';
             $score -= 5;
@@ -212,7 +206,7 @@ class EvalSuiteController extends Controller
             'data' => [
                 'score' => $score,
                 'issues' => $issues,
-                'name' => $name,
+                'name' => $skill->name,
                 'description' => $description,
                 'summary' => $summary,
             ],

--- a/app/Http/Controllers/SkillController.php
+++ b/app/Http/Controllers/SkillController.php
@@ -161,7 +161,7 @@ class SkillController extends Controller
 
     public function lint(Skill $skill, PromptLinter $linter): JsonResponse
     {
-        $issues = $linter->lint($skill->body ?? '');
+        $issues = $linter->lintSkill($skill);
 
         return response()->json(['data' => $issues]);
     }

--- a/app/Services/PromptLinter.php
+++ b/app/Services/PromptLinter.php
@@ -2,8 +2,44 @@
 
 namespace App\Services;
 
+use App\Models\Skill;
+
 class PromptLinter
 {
+    /**
+     * Vague words that weaken a skill description's discoverability.
+     *
+     * @var array<int, string>
+     */
+    public const VAGUE_DESCRIPTION_WORDS = ['stuff', 'things', 'various', 'general', 'misc'];
+
+    /**
+     * Action verbs expected in a skill description so agents can route to it.
+     *
+     * @var array<int, string>
+     */
+    public const DESCRIPTION_ACTION_VERBS = [
+        'generate', 'create', 'analyze', 'review', 'check', 'format',
+        'convert', 'summarize', 'explain', 'debug', 'test', 'deploy',
+        'automate', 'enforce',
+    ];
+
+    /**
+     * Lint a full skill (body + metadata).
+     *
+     * @return array<int, array{severity: string, rule: string, message: string, suggestion: string, line: int|null}>
+     */
+    public function lintSkill(Skill $skill): array
+    {
+        $issues = $this->lint($skill->body ?? '');
+
+        $this->checkMissingSummary($skill->summary ?? '', $issues);
+        $this->checkMissingDescription($skill->description ?? '', $issues);
+        $this->checkNoProgressiveDisclosure($skill->body ?? '', $issues);
+
+        return $issues;
+    }
+
     /**
      * Lint a skill body and return an array of issues.
      *
@@ -199,6 +235,100 @@ class PromptLinter
 
             $normalized[] = [$idx, $trimmed];
         }
+    }
+
+    protected function checkMissingSummary(string $summary, array &$issues): void
+    {
+        if (trim($summary) === '') {
+            $issues[] = [
+                'severity' => 'suggestion',
+                'rule' => 'missing_summary',
+                'message' => 'No summary set — tier-1 progressive disclosure will fall back to description.',
+                'suggestion' => 'Add a one-line summary describing when to use this skill.',
+                'line' => null,
+            ];
+        }
+    }
+
+    protected function checkMissingDescription(string $description, array &$issues): void
+    {
+        $trimmed = trim($description);
+
+        if ($trimmed === '') {
+            $issues[] = [
+                'severity' => 'warning',
+                'rule' => 'missing_description',
+                'message' => 'Description is empty — agents may not know when to use this skill.',
+                'suggestion' => 'Add a description with an actionable verb explaining when the skill applies.',
+                'line' => null,
+            ];
+
+            return;
+        }
+
+        if (strlen($trimmed) < 20) {
+            $issues[] = [
+                'severity' => 'warning',
+                'rule' => 'missing_description',
+                'message' => 'Description is too short — may not trigger when needed.',
+                'suggestion' => 'Expand to at least 20 characters with an actionable verb and trigger conditions.',
+                'line' => null,
+            ];
+        }
+
+        foreach (self::VAGUE_DESCRIPTION_WORDS as $word) {
+            if (stripos($trimmed, $word) !== false) {
+                $issues[] = [
+                    'severity' => 'warning',
+                    'rule' => 'missing_description',
+                    'message' => "Description contains vague word: \"{$word}\".",
+                    'suggestion' => 'Replace vague words with specific triggers or subjects.',
+                    'line' => null,
+                ];
+                break;
+            }
+        }
+
+        $hasVerb = false;
+        foreach (self::DESCRIPTION_ACTION_VERBS as $verb) {
+            if (stripos($trimmed, $verb) !== false) {
+                $hasVerb = true;
+                break;
+            }
+        }
+
+        if (! $hasVerb) {
+            $issues[] = [
+                'severity' => 'warning',
+                'rule' => 'missing_description',
+                'message' => 'Description lacks an actionable verb — agents may not know when to use this skill.',
+                'suggestion' => 'Add a verb like "generate", "analyze", "review", or "summarize".',
+                'line' => null,
+            ];
+        }
+    }
+
+    protected function checkNoProgressiveDisclosure(string $body, array &$issues): void
+    {
+        if (strlen($body) <= 500) {
+            return;
+        }
+
+        $firstLines = array_slice(explode("\n", $body), 0, 40);
+
+        foreach ($firstLines as $line) {
+            if (preg_match('/^\s{0,3}#{2,3}\s+\S/', $line)) {
+                return;
+            }
+        }
+
+        $issues[] = [
+            'severity' => 'suggestion',
+            'rule' => 'no_progressive_disclosure',
+            'message' => 'Long skill without ## or ### headings in the first 40 lines.',
+            'suggestion' => 'Add section headings so the model can skim before committing to details.',
+            'line' => null,
+        ];
     }
 
     protected function checkSecrets(array $lines, array &$issues): void

--- a/tests/Feature/PromptLinterTest.php
+++ b/tests/Feature/PromptLinterTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use App\Models\Skill;
+use App\Services\PromptLinter;
+
+beforeEach(function () {
+    $this->linter = new PromptLinter;
+});
+
+it('flags missing_summary when summary is empty', function () {
+    $skill = new Skill([
+        'name' => 'Test',
+        'description' => 'Generate a structured summary of the input document.',
+        'summary' => '',
+        'body' => 'You are a helpful assistant.',
+    ]);
+
+    $rules = array_column($this->linter->lintSkill($skill), 'rule');
+
+    expect($rules)->toContain('missing_summary');
+});
+
+it('does not flag missing_summary when summary is present', function () {
+    $skill = new Skill([
+        'name' => 'Test',
+        'description' => 'Generate a structured summary of the input document.',
+        'summary' => 'Summarizes documents.',
+        'body' => 'You are a helpful assistant.',
+    ]);
+
+    $rules = array_column($this->linter->lintSkill($skill), 'rule');
+
+    expect($rules)->not->toContain('missing_summary');
+});
+
+it('flags missing_description when description is empty', function () {
+    $skill = new Skill([
+        'name' => 'Test',
+        'description' => '',
+        'summary' => 'Does a thing.',
+        'body' => 'You are a helpful assistant.',
+    ]);
+
+    $rules = array_column($this->linter->lintSkill($skill), 'rule');
+
+    expect($rules)->toContain('missing_description');
+});
+
+it('flags missing_description when description contains vague words', function () {
+    $skill = new Skill([
+        'name' => 'Test',
+        'description' => 'Handles various stuff for the user.',
+        'summary' => 'x',
+        'body' => 'You are a helpful assistant.',
+    ]);
+
+    $issues = $this->linter->lintSkill($skill);
+    $descriptionIssues = array_filter($issues, fn ($i) => $i['rule'] === 'missing_description');
+
+    expect($descriptionIssues)->not->toBeEmpty();
+});
+
+it('flags missing_description when description lacks action verb', function () {
+    $skill = new Skill([
+        'name' => 'Test',
+        'description' => 'A specific helper that works on user input nicely.',
+        'summary' => 'x',
+        'body' => 'You are a helpful assistant.',
+    ]);
+
+    $messages = array_map(
+        fn ($i) => $i['message'],
+        array_filter($this->linter->lintSkill($skill), fn ($i) => $i['rule'] === 'missing_description')
+    );
+
+    expect(implode(' ', $messages))->toContain('actionable verb');
+});
+
+it('does not flag missing_description when description is specific and actionable', function () {
+    $skill = new Skill([
+        'name' => 'Test',
+        'description' => 'Generate a structured summary of technical documents for review.',
+        'summary' => 'x',
+        'body' => 'You are a helpful assistant.',
+    ]);
+
+    $rules = array_column($this->linter->lintSkill($skill), 'rule');
+
+    expect($rules)->not->toContain('missing_description');
+});
+
+it('flags no_progressive_disclosure when long body has no headings', function () {
+    $body = str_repeat('This is a long instruction without any section headings at all. ', 20);
+
+    $skill = new Skill([
+        'name' => 'Test',
+        'description' => 'Generate structured output from input data.',
+        'summary' => 'x',
+        'body' => $body,
+    ]);
+
+    $rules = array_column($this->linter->lintSkill($skill), 'rule');
+
+    expect(strlen($body))->toBeGreaterThan(500)
+        ->and($rules)->toContain('no_progressive_disclosure');
+});
+
+it('does not flag no_progressive_disclosure when body has ## heading in first 40 lines', function () {
+    $body = "## Overview\n\n" . str_repeat('Long detailed instruction content goes here on this line. ', 20);
+
+    $skill = new Skill([
+        'name' => 'Test',
+        'description' => 'Generate structured output from input data.',
+        'summary' => 'x',
+        'body' => $body,
+    ]);
+
+    $rules = array_column($this->linter->lintSkill($skill), 'rule');
+
+    expect($rules)->not->toContain('no_progressive_disclosure');
+});
+
+it('does not flag no_progressive_disclosure when body is short', function () {
+    $skill = new Skill([
+        'name' => 'Test',
+        'description' => 'Generate structured output from input data.',
+        'summary' => 'x',
+        'body' => 'Short body with no headings.',
+    ]);
+
+    $rules = array_column($this->linter->lintSkill($skill), 'rule');
+
+    expect($rules)->not->toContain('no_progressive_disclosure');
+});

--- a/ui/src/components/skills/GotchaPanel.tsx
+++ b/ui/src/components/skills/GotchaPanel.tsx
@@ -11,6 +11,7 @@ import type { SkillGotcha } from '@/types'
 
 interface GotchaPanelProps {
   skillId: number
+  onMutate?: () => void
 }
 
 const SEVERITY_STYLES: Record<
@@ -26,7 +27,7 @@ const SEVERITY_STYLES: Record<
   info: { bg: 'bg-blue-500/10', text: 'text-blue-500', label: 'Info' },
 }
 
-export function GotchaPanel({ skillId }: GotchaPanelProps) {
+export function GotchaPanel({ skillId, onMutate }: GotchaPanelProps) {
   const confirm = useConfirm()
   const [gotchas, setGotchas] = useState<SkillGotcha[]>([])
   const [loading, setLoading] = useState(true)
@@ -56,22 +57,26 @@ export function GotchaPanel({ skillId }: GotchaPanelProps) {
     setSeverity('warning')
     setShowForm(false)
     load()
+    onMutate?.()
   }
 
   const handleDelete = async (id: number) => {
     if (!(await confirm({ message: 'Delete this gotcha?', title: 'Confirm Delete' }))) return
     await deleteGotcha(id)
     load()
+    onMutate?.()
   }
 
   const handleResolve = async (id: number) => {
     await resolveGotcha(id)
     load()
+    onMutate?.()
   }
 
   const handleReopen = async (id: number) => {
     await reopenGotcha(id)
     load()
+    onMutate?.()
   }
 
   if (loading) {

--- a/ui/src/components/skills/InlineGotchaStrip.tsx
+++ b/ui/src/components/skills/InlineGotchaStrip.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react'
+import { fetchGotchas } from '@/api/client'
+import type { SkillGotcha } from '@/types'
+
+interface InlineGotchaStripProps {
+  skillId: number
+  refreshKey?: number
+  onManage: () => void
+}
+
+const SEVERITY_ORDER: SkillGotcha['severity'][] = ['critical', 'warning', 'info']
+
+const SEVERITY_DOT: Record<SkillGotcha['severity'], string> = {
+  critical: 'bg-red-500',
+  warning: 'bg-yellow-500',
+  info: 'bg-blue-500',
+}
+
+const SEVERITY_LABEL: Record<SkillGotcha['severity'], string> = {
+  critical: 'critical',
+  warning: 'warning',
+  info: 'info',
+}
+
+export function InlineGotchaStrip({ skillId, refreshKey = 0, onManage }: InlineGotchaStripProps) {
+  const [active, setActive] = useState<SkillGotcha[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+    fetchGotchas(skillId, true)
+      .then((list) => {
+        if (!cancelled) setActive(list)
+      })
+      .catch(() => {
+        if (!cancelled) setActive([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [skillId, refreshKey])
+
+  if (active.length === 0) return null
+
+  const counts = SEVERITY_ORDER.map((sev) => ({
+    sev,
+    count: active.filter((g) => g.severity === sev).length,
+  })).filter((c) => c.count > 0)
+
+  const topCritical = active
+    .filter((g) => g.severity === 'critical')
+    .slice(0, 2)
+    .map((g) => g.title)
+
+  return (
+    <div className="flex items-center gap-3 px-3 h-8 border-b border-border bg-yellow-500/5 text-xs">
+      <div className="flex items-center gap-2 shrink-0">
+        {counts.map(({ sev, count }) => (
+          <span key={sev} className="flex items-center gap-1">
+            <span className={`w-1.5 h-1.5 rounded-full ${SEVERITY_DOT[sev]}`} />
+            <span className="text-muted-foreground">
+              {count} {SEVERITY_LABEL[sev]}
+            </span>
+          </span>
+        ))}
+      </div>
+      {topCritical.length > 0 && (
+        <div className="flex-1 min-w-0 text-foreground/80 truncate">
+          {topCritical.join(' · ')}
+        </div>
+      )}
+      {topCritical.length === 0 && <div className="flex-1" />}
+      <button
+        onClick={onManage}
+        className="shrink-0 text-primary hover:underline font-medium"
+      >
+        manage
+      </button>
+    </div>
+  )
+}

--- a/ui/src/pages/SkillEditor.tsx
+++ b/ui/src/pages/SkillEditor.tsx
@@ -22,6 +22,7 @@ import { RegressionTestPanel } from '@/components/skills/RegressionTestPanel'
 import { InheritancePanel } from '@/components/skills/InheritancePanel'
 import { AssetsPanel } from '@/components/skills/AssetsPanel'
 import { GotchaPanel } from '@/components/skills/GotchaPanel'
+import { InlineGotchaStrip } from '@/components/skills/InlineGotchaStrip'
 import { EvalPanel } from '@/components/skills/EvalPanel'
 import { GenerateSkillModal } from '@/components/skills/GenerateSkillModal'
 import { useConfirm } from '@/hooks/useConfirm'
@@ -51,6 +52,7 @@ export function SkillEditor() {
   const [saving, setSaving] = useState(false)
   const [activeTab, setActiveTab] = useState<'test' | 'versions' | 'lint' | 'gotchas' | 'evals' | 'assets' | 'security' | 'review' | 'regression' | 'inherit'>('test')
   const [showGenerate, setShowGenerate] = useState(false)
+  const [gotchaRefreshKey, setGotchaRefreshKey] = useState(0)
   const { isDirty, setDirty, showToast, loadProjects } = useAppStore()
   const confirm = useConfirm()
   const initialBody = useRef<string>('')
@@ -213,6 +215,13 @@ export function SkillEditor() {
         {/* Left: Editor */}
         <div className="flex-1 flex flex-col min-w-0 min-h-0">
           <FrontmatterForm skill={skill} onChange={handleFieldChange} projectSkills={projectSkills} />
+          {!isNew && skill.id && (
+            <InlineGotchaStrip
+              skillId={skill.id}
+              refreshKey={gotchaRefreshKey}
+              onManage={() => setActiveTab('gotchas')}
+            />
+          )}
           {!isNew &&
             skill.id &&
             skill.project_id &&
@@ -283,7 +292,10 @@ export function SkillEditor() {
               ) : activeTab === 'lint' ? (
                 <LintPanel skillId={skill.id} />
               ) : activeTab === 'gotchas' ? (
-                <GotchaPanel skillId={skill.id} />
+                <GotchaPanel
+                  skillId={skill.id}
+                  onMutate={() => setGotchaRefreshKey((k) => k + 1)}
+                />
               ) : activeTab === 'evals' ? (
                 <EvalPanel skillId={skill.id} />
               ) : activeTab === 'assets' ? (


### PR DESCRIPTION
## Summary

Phase 0 of the [Harness Engineering roadmap](https://github.com/eooo-io/orkestr/milestone/112) — two quick wins, frontend-only + lint-only, no migrations.

- **#525** — `InlineGotchaStrip` always-visible above Monaco in `SkillEditor`. Severity-count dots, top 2 critical titles, "manage" link that jumps to the Gotchas tab. Hidden when no open gotchas. `GotchaPanel` gained an `onMutate` callback so the strip refreshes on mutations via a shared `refreshKey`.
- **#526** — `PromptLinter::lintSkill(Skill)` overload with access to `summary`, `description`, `name`. Three new rules:
  - `missing_summary` (suggestion)
  - `missing_description` (warning, reuses the vague-word + action-verb lists)
  - `no_progressive_disclosure` (suggestion, fires when body >500 chars and no `##`/`###` in first 40 lines)
- `SkillController::lint` dispatches to `lintSkill`; `EvalSuiteController::scoreDescription` delegates to shared `PromptLinter::VAGUE_DESCRIPTION_WORDS` and `DESCRIPTION_ACTION_VERBS` constants so the two surfaces can't drift.

## Test plan

- [x] 9 new Pest tests in `tests/Feature/PromptLinterTest.php` — all pass
- [x] Existing 10 `AdminSecurityTest` PromptLinter tests still pass
- [x] `ui/` TypeScript check clean
- [ ] Manual: open a skill with no gotchas — strip hidden
- [ ] Manual: create a critical gotcha — strip appears with red dot + title
- [ ] Manual: click "manage" — active tab switches to `gotchas`
- [ ] Manual: resolve the gotcha from the panel — strip disappears

Closes #525
Closes #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)