### PR TITLE
Phase 2: compose preview sharing + model override (#530–#533)

### DIFF
--- a/app/Http/Controllers/AgentController.php
+++ b/app/Http/Controllers/AgentController.php
@@ -482,9 +482,10 @@ class AgentController extends Controller
     public function compose(Request $request, Project $project, Agent $agent): JsonResponse
     {
         $depth = $request->query('depth', 'full');
+        $modelOverride = $request->query('model');
 
         return response()->json([
-            'data' => $this->composeService->compose($project, $agent, $depth),
+            'data' => $this->composeService->compose($project, $agent, $depth, $modelOverride),
         ]);
     }
 

--- a/app/Http/Controllers/ComposeShareController.php
+++ b/app/Http/Controllers/ComposeShareController.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Agent;
+use App\Models\ComposeShareLink;
+use App\Models\Project;
+use App\Services\AgentComposeService;
+use App\Services\PromptLinter;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class ComposeShareController extends Controller
+{
+    protected const DEFAULT_EXPIRY_DAYS = 7;
+
+    public function __construct(
+        protected AgentComposeService $composeService,
+        protected PromptLinter $linter,
+    ) {}
+
+    public function store(Request $request, Project $project, Agent $agent): JsonResponse
+    {
+        $validated = $request->validate([
+            'model' => 'nullable|string|max:100',
+            'depth' => 'nullable|string|in:index,full,deep',
+            'expires_in_days' => 'nullable|integer|min:1|max:90',
+            'is_snapshot' => 'nullable|boolean',
+        ]);
+
+        $depth = $validated['depth'] ?? 'full';
+        $modelOverride = $validated['model'] ?? null;
+        $isSnapshot = $validated['is_snapshot'] ?? true;
+        $expiresInDays = $validated['expires_in_days'] ?? self::DEFAULT_EXPIRY_DAYS;
+
+        $composed = $this->composeService->compose($project, $agent, $depth, $modelOverride);
+
+        $secretIssues = array_values(array_filter(
+            $this->linter->lint($composed['content']),
+            fn ($issue) => $issue['rule'] === 'secret_in_prompt',
+        ));
+
+        if (! empty($secretIssues)) {
+            return response()->json([
+                'error' => 'Refusing to create share link: composed output contains potential secrets.',
+                'secrets' => $secretIssues,
+            ], 422);
+        }
+
+        $payload = $isSnapshot ? $this->sanitizePayload($composed) : null;
+
+        $link = ComposeShareLink::create([
+            'project_id' => $project->id,
+            'agent_id' => $agent->id,
+            'model' => $modelOverride,
+            'depth' => $depth,
+            'created_by' => Auth::id(),
+            'expires_at' => now()->addDays($expiresInDays),
+            'is_snapshot' => $isSnapshot,
+            'snapshot_payload' => $payload,
+        ]);
+
+        return response()->json([
+            'data' => [
+                'uuid' => $link->uuid,
+                'url' => $this->shareUrl($link),
+                'expires_at' => $link->expires_at->toIso8601String(),
+                'is_snapshot' => $link->is_snapshot,
+            ],
+        ], 201);
+    }
+
+    public function destroy(Request $request, string $uuid): JsonResponse
+    {
+        $link = ComposeShareLink::where('uuid', $uuid)->firstOrFail();
+
+        if ($link->created_by !== Auth::id()) {
+            abort(403, 'Only the creator can delete this share link.');
+        }
+
+        $link->delete();
+
+        return response()->json(['message' => 'Share link deleted']);
+    }
+
+    public function show(string $uuid): JsonResponse
+    {
+        $link = ComposeShareLink::where('uuid', $uuid)->first();
+
+        if (! $link) {
+            abort(404, 'Share link not found.');
+        }
+
+        if ($link->isExpired()) {
+            abort(410, 'Share link has expired.');
+        }
+
+        if ($link->is_snapshot && $link->snapshot_payload) {
+            $payload = $link->snapshot_payload;
+        } else {
+            $project = $link->project;
+            $agent = $link->agent;
+            $payload = $this->sanitizePayload(
+                $this->composeService->compose($project, $agent, $link->depth, $link->model)
+            );
+        }
+
+        $link->increment('access_count');
+        $link->update(['last_accessed_at' => now()]);
+
+        return response()->json([
+            'data' => array_merge($payload, [
+                'uuid' => $link->uuid,
+                'expires_at' => $link->expires_at?->toIso8601String(),
+                'is_snapshot' => $link->is_snapshot,
+            ]),
+        ]);
+    }
+
+    protected function shareUrl(ComposeShareLink $link): string
+    {
+        return url("/share/compose/{$link->uuid}");
+    }
+
+    /**
+     * Strip anything with a `secret_*` prefix out of any attached variable maps.
+     * Right now the compose payload doesn't include raw variable maps, but this
+     * belt-and-suspenders helper protects against future shape changes leaking them.
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    protected function sanitizePayload(array $payload): array
+    {
+        if (isset($payload['skill_variables']) && is_array($payload['skill_variables'])) {
+            $payload['skill_variables'] = array_filter(
+                $payload['skill_variables'],
+                fn ($_value, $key) => ! str_starts_with((string) $key, 'secret_'),
+                ARRAY_FILTER_USE_BOTH,
+            );
+        }
+
+        return $payload;
+    }
+}

--- a/app/Models/ComposeShareLink.php
+++ b/app/Models/ComposeShareLink.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Str;
+
+class ComposeShareLink extends Model
+{
+    protected $fillable = [
+        'uuid',
+        'project_id',
+        'agent_id',
+        'model',
+        'depth',
+        'created_by',
+        'expires_at',
+        'last_accessed_at',
+        'access_count',
+        'is_snapshot',
+        'snapshot_payload',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'expires_at' => 'datetime',
+            'last_accessed_at' => 'datetime',
+            'is_snapshot' => 'boolean',
+            'snapshot_payload' => 'array',
+            'access_count' => 'integer',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::creating(function (ComposeShareLink $link) {
+            if (empty($link->uuid)) {
+                $link->uuid = (string) Str::uuid();
+            }
+        });
+    }
+
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function agent(): BelongsTo
+    {
+        return $this->belongsTo(Agent::class);
+    }
+
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function isExpired(): bool
+    {
+        return $this->expires_at !== null && $this->expires_at->isPast();
+    }
+}

--- a/app/Services/AgentComposeService.php
+++ b/app/Services/AgentComposeService.php
@@ -7,6 +7,7 @@ use App\Models\Project;
 use App\Models\ProjectAgent;
 use App\Models\Skill;
 use App\Models\SkillVariable;
+use App\Services\LLM\LLMProviderFactory;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 
@@ -15,16 +16,22 @@ class AgentComposeService
     public function __construct(
         protected SkillCompositionService $compositionService,
         protected TemplateResolver $templateResolver,
+        protected LLMProviderFactory $llmFactory,
     ) {}
 
     /**
      * Compose the full markdown output for a single project agent.
      *
      * @param  string  $depth  Compose depth: 'index', 'full', or 'deep'
-     * @return array{content: string, token_estimate: int, agent: array, skill_count: int}
+     * @param  string|null  $modelOverride  Preview against a different model than the agent is configured for
+     * @return array{content: string, token_estimate: int, agent: array, skill_count: int, target_model: string|null, model_context_window: int, skill_breakdown: array}
      */
-    public function compose(Project $project, Agent $agent, string $depth = 'full'): array
-    {
+    public function compose(
+        Project $project,
+        Agent $agent,
+        string $depth = 'full',
+        ?string $modelOverride = null,
+    ): array {
         $projectAgent = $project->projectAgents()
             ->where('agent_id', $agent->id)
             ->first();
@@ -32,11 +39,13 @@ class AgentComposeService
         $customInstructions = $projectAgent?->custom_instructions;
 
         $skills = $this->getAssignedSkills($project, $agent);
-        $content = $this->render($project, $agent, $customInstructions, $skills, $depth);
+        $rendered = $this->renderWithOffsets($project, $agent, $customInstructions, $skills, $depth);
+
+        $targetModel = $modelOverride ?? $projectAgent?->model_override ?? $agent->model;
 
         return [
-            'content' => $content,
-            'token_estimate' => $this->estimateTokens($content),
+            'content' => $rendered['content'],
+            'token_estimate' => $this->estimateTokens($rendered['content']),
             'agent' => [
                 'id' => $agent->id,
                 'name' => $agent->name,
@@ -47,6 +56,9 @@ class AgentComposeService
                 'display_name' => $agent->displayName(),
             ],
             'skill_count' => $skills->count(),
+            'target_model' => $targetModel,
+            'model_context_window' => $targetModel ? $this->llmFactory->contextWindowFor($targetModel) : 0,
+            'skill_breakdown' => $rendered['skill_breakdown'],
         ];
     }
 
@@ -410,53 +422,108 @@ class AgentComposeService
      */
     protected function render(Project $project, Agent $agent, ?string $customInstructions, \Illuminate\Support\Collection $skills, string $depth = 'full'): string
     {
+        return $this->renderWithOffsets($project, $agent, $customInstructions, $skills, $depth)['content'];
+    }
+
+    /**
+     * Render the composed markdown output and record per-skill character offsets.
+     *
+     * @return array{content: string, skill_breakdown: array<int, array{slug: string, name: string, token_estimate: int, starts_at_char: int, ends_at_char: int, tuned_for_model: string|null, last_validated_model: string|null}>}
+     */
+    protected function renderWithOffsets(
+        Project $project,
+        Agent $agent,
+        ?string $customInstructions,
+        \Illuminate\Support\Collection $skills,
+        string $depth = 'full',
+    ): array {
         $sections = [];
 
-        // Header — use persona name if available
         $sections[] = "# {$agent->displayName()}";
 
-        // Persona context
         if ($personaContext = $agent->personaContext()) {
             $sections[] = $personaContext;
         }
 
-        // Base instructions
         if ($agent->base_instructions) {
             $sections[] = trim($agent->base_instructions);
         }
 
-        // Custom project-specific instructions
         if ($customInstructions) {
             $sections[] = "## Project-Specific Instructions\n\n" . trim($customInstructions);
         }
 
-        // Resolved skill sections
         $resolvedSkills = $this->resolveSkillBodies($project, $skills, $depth);
+        $skillBreakdown = [];
 
         if (! empty($resolvedSkills)) {
             if ($depth === 'index') {
-                // Index mode: just list skill names and summaries
-                $skillSections = ["## Available Skills"];
+                $skillSections = ['## Available Skills'];
                 foreach ($resolvedSkills as $skill) {
                     $summary = $skill['summary'] ?? $skill['description'] ?? '';
                     $skillSections[] = "- **{$skill['name']}**: {$summary}";
                 }
                 $sections[] = implode("\n", $skillSections);
-            } else {
-                $skillSections = ["## Assigned Skills"];
+
+                $content = implode("\n\n", $sections) . "\n";
+                $skillsById = $skills->keyBy('id');
                 foreach ($resolvedSkills as $skill) {
-                    $skillContent = "### {$skill['name']}";
-                    if ($skill['description']) {
-                        $skillContent .= "\n\n> {$skill['description']}";
-                    }
-                    $skillContent .= "\n\n" . trim($skill['body']);
-                    $skillSections[] = $skillContent;
+                    $model = $skillsById->get($skill['id']);
+                    $skillBreakdown[] = [
+                        'slug' => $skill['slug'],
+                        'name' => $skill['name'],
+                        'token_estimate' => $skill['token_estimate'],
+                        'starts_at_char' => 0,
+                        'ends_at_char' => 0,
+                        'tuned_for_model' => $model?->tuned_for_model,
+                        'last_validated_model' => $model?->last_validated_model,
+                    ];
                 }
-                $sections[] = implode("\n\n", $skillSections);
+
+                return ['content' => $content, 'skill_breakdown' => $skillBreakdown];
             }
+
+            $prefix = implode("\n\n", $sections);
+            // The "## Assigned Skills" header lives above the first skill; include the
+            // join separator so offsets point at the "### {name}" line exactly.
+            $prefix .= "\n\n## Assigned Skills\n\n";
+
+            $skillsById = $skills->keyBy('id');
+            $content = $prefix;
+            foreach ($resolvedSkills as $idx => $skill) {
+                $skillContent = "### {$skill['name']}";
+                if ($skill['description']) {
+                    $skillContent .= "\n\n> {$skill['description']}";
+                }
+                $skillContent .= "\n\n" . trim($skill['body']);
+
+                $startsAt = strlen($content);
+                $content .= $skillContent;
+                $endsAt = strlen($content);
+
+                $model = $skillsById->get($skill['id']);
+                $skillBreakdown[] = [
+                    'slug' => $skill['slug'],
+                    'name' => $skill['name'],
+                    'token_estimate' => $skill['token_estimate'],
+                    'starts_at_char' => $startsAt,
+                    'ends_at_char' => $endsAt,
+                    'tuned_for_model' => $model?->tuned_for_model,
+                    'last_validated_model' => $model?->last_validated_model,
+                ];
+
+                if ($idx < count($resolvedSkills) - 1) {
+                    $content .= "\n\n";
+                }
+            }
+
+            return ['content' => $content . "\n", 'skill_breakdown' => $skillBreakdown];
         }
 
-        return implode("\n\n", $sections) . "\n";
+        return [
+            'content' => implode("\n\n", $sections) . "\n",
+            'skill_breakdown' => $skillBreakdown,
+        ];
     }
 
     /**

--- a/app/Services/LLM/LLMProviderFactory.php
+++ b/app/Services/LLM/LLMProviderFactory.php
@@ -8,6 +8,37 @@ use App\Models\CustomEndpoint;
 class LLMProviderFactory
 {
     /**
+     * Static context window lookup. Shared between formatModels() and contextWindowFor().
+     *
+     * @var array<string, int>
+     */
+    public const CONTEXT_WINDOWS = [
+        'claude-opus-4-6' => 200000,
+        'claude-sonnet-4-6' => 200000,
+        'claude-haiku-4-5-20251001' => 200000,
+        'gpt-5.4' => 1048576,
+        'gpt-5.4-thinking' => 1048576,
+        'gpt-5-mini' => 1048576,
+        'gpt-5.3-instant' => 1048576,
+        'o3' => 200000,
+        'gemini-3.1-pro' => 1048576,
+        'gemini-3-flash' => 1048576,
+        'gemini-3.1-flash-lite' => 1048576,
+        'grok-3' => 131072,
+        'grok-3-fast' => 131072,
+        'grok-3-mini' => 131072,
+        'grok-3-mini-fast' => 131072,
+    ];
+
+    /**
+     * Return the context window for a model, or 0 if unknown.
+     */
+    public function contextWindowFor(string $model): int
+    {
+        return self::CONTEXT_WINDOWS[$model] ?? 0;
+    }
+
+    /**
      * Create a provider instance for the given model name.
      */
     public function make(string $model): LLMProviderInterface
@@ -129,24 +160,6 @@ class LLMProviderFactory
 
     protected function formatModels(array $modelIds, string $provider): array
     {
-        $contextWindows = [
-            'claude-opus-4-6' => 200000,
-            'claude-sonnet-4-6' => 200000,
-            'claude-haiku-4-5-20251001' => 200000,
-            'gpt-5.4' => 1048576,
-            'gpt-5.4-thinking' => 1048576,
-            'gpt-5-mini' => 1048576,
-            'gpt-5.3-instant' => 1048576,
-            'o3' => 200000,
-            'gemini-3.1-pro' => 1048576,
-            'gemini-3-flash' => 1048576,
-            'gemini-3.1-flash-lite' => 1048576,
-            'grok-3' => 131072,
-            'grok-3-fast' => 131072,
-            'grok-3-mini' => 131072,
-            'grok-3-mini-fast' => 131072,
-        ];
-
         $labels = [
             'claude-opus-4-6' => 'Claude Opus 4.6',
             'claude-sonnet-4-6' => 'Claude Sonnet 4.6',
@@ -169,7 +182,7 @@ class LLMProviderFactory
             'id' => $id,
             'name' => $labels[$id] ?? $id,
             'provider' => $provider,
-            'context_window' => $contextWindows[$id] ?? 0,
+            'context_window' => self::CONTEXT_WINDOWS[$id] ?? 0,
         ], $modelIds);
     }
 

--- a/database/migrations/2026_04_18_154212_create_compose_share_links_table.php
+++ b/database/migrations/2026_04_18_154212_create_compose_share_links_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('compose_share_links', function (Blueprint $table) {
+            $table->id();
+            $table->uuid('uuid')->unique();
+            $table->foreignId('project_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('agent_id')->constrained()->cascadeOnDelete();
+            $table->string('model', 100)->nullable();
+            $table->string('depth', 20)->default('full');
+            $table->foreignId('created_by')->constrained('users')->cascadeOnDelete();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamp('last_accessed_at')->nullable();
+            $table->unsignedInteger('access_count')->default(0);
+            $table->boolean('is_snapshot')->default(true);
+            $table->longText('snapshot_payload')->nullable();
+            $table->timestamps();
+
+            $table->index(['project_id', 'agent_id']);
+            $table->index('expires_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('compose_share_links');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\AgentController;
+use App\Http\Controllers\ComposeShareController;
 use App\Http\Controllers\ArtifactController;
 use App\Http\Controllers\BundleController;
 use App\Http\Controllers\LibraryController;
@@ -96,6 +97,10 @@ Route::post('/a2a/{agentSlug}/execute', [App\Http\Controllers\A2aExecutionContro
 // OpenAPI spec & docs (public)
 Route::get('/openapi.json', [OpenApiController::class, 'spec']);
 Route::get('/docs', [OpenApiController::class, 'docs']);
+
+// Public compose share (rate-limited)
+Route::get('/share/compose/{uuid}', [ComposeShareController::class, 'show'])
+    ->middleware('throttle:30,1');
 
 // ─── Authenticated Routes ────────────────────────────────────
 Route::middleware('auth:web')->group(function () {
@@ -256,6 +261,8 @@ Route::middleware('auth:web')->group(function () {
     Route::put('/projects/{project}/agents/{agent}/a2a-agents', [AgentController::class, 'bindA2aAgents']);
     Route::get('/projects/{project}/agents/{agent}/compose', [AgentController::class, 'compose']);
     Route::get('/projects/{project}/agents/{agent}/compose-structured', [AgentController::class, 'composeStructured']);
+    Route::post('/projects/{project}/agents/{agent}/compose/share', [ComposeShareController::class, 'store'])->middleware('org-role:editor');
+    Route::delete('/share/compose/{uuid}', [ComposeShareController::class, 'destroy']);
     Route::get('/projects/{project}/agents/compose', [AgentController::class, 'composeAll']);
 
     // Bundles (Export/Import)

--- a/tests/Feature/AgentComposeServiceTest.php
+++ b/tests/Feature/AgentComposeServiceTest.php
@@ -70,6 +70,66 @@ it('composes markdown with assigned skills', function () {
     expect($result['skill_count'])->toBe(1);
 });
 
+it('returns target_model and model_context_window from agent model', function () {
+    $result = $this->service->compose($this->project, $this->agent);
+
+    expect($result['target_model'])->toBe('claude-sonnet-4-6')
+        ->and($result['model_context_window'])->toBe(200000);
+});
+
+it('applies modelOverride to target_model and context window', function () {
+    $result = $this->service->compose($this->project, $this->agent, 'full', 'gpt-5.4');
+
+    expect($result['target_model'])->toBe('gpt-5.4')
+        ->and($result['model_context_window'])->toBe(1048576);
+});
+
+it('returns 0 context_window for an unknown model', function () {
+    $result = $this->service->compose($this->project, $this->agent, 'full', 'mystery-model');
+
+    expect($result['target_model'])->toBe('mystery-model')
+        ->and($result['model_context_window'])->toBe(0);
+});
+
+it('returns skill_breakdown with offsets aligned to content', function () {
+    $skillA = Skill::create([
+        'project_id' => $this->project->id,
+        'name' => 'Alpha Skill',
+        'slug' => 'alpha-skill',
+        'body' => 'Alpha body content.',
+        'tuned_for_model' => 'claude-sonnet-4-6',
+    ]);
+    $skillB = Skill::create([
+        'project_id' => $this->project->id,
+        'name' => 'Beta Skill',
+        'slug' => 'beta-skill',
+        'body' => 'Beta body content.',
+        'last_validated_model' => 'claude-opus-4-6',
+    ]);
+
+    DB::table('agent_skill')->insert([
+        ['project_id' => $this->project->id, 'agent_id' => $this->agent->id, 'skill_id' => $skillA->id],
+        ['project_id' => $this->project->id, 'agent_id' => $this->agent->id, 'skill_id' => $skillB->id],
+    ]);
+
+    $result = $this->service->compose($this->project, $this->agent);
+    $breakdown = $result['skill_breakdown'];
+
+    expect($breakdown)->toHaveCount(2);
+
+    foreach ($breakdown as $entry) {
+        $slice = substr($result['content'], $entry['starts_at_char'], $entry['ends_at_char'] - $entry['starts_at_char']);
+        expect($slice)->toStartWith("### {$entry['name']}");
+    }
+
+    $alphaEntry = collect($breakdown)->firstWhere('slug', 'alpha-skill');
+    $betaEntry = collect($breakdown)->firstWhere('slug', 'beta-skill');
+
+    expect($alphaEntry['tuned_for_model'])->toBe('claude-sonnet-4-6')
+        ->and($betaEntry['last_validated_model'])->toBe('claude-opus-4-6')
+        ->and($alphaEntry['ends_at_char'])->toBeLessThanOrEqual($betaEntry['starts_at_char']);
+});
+
 it('includes custom instructions in compose', function () {
     ProjectAgent::where('project_id', $this->project->id)
         ->where('agent_id', $this->agent->id)

--- a/tests/Feature/AgentPersonaTest.php
+++ b/tests/Feature/AgentPersonaTest.php
@@ -160,10 +160,7 @@ test('compose includes persona context in output', function () {
 
     $project->agents()->attach($agent->id, ['is_enabled' => true]);
 
-    $composer = new AgentComposeService(
-        new SkillCompositionService(),
-        new TemplateResolver(),
-    );
+    $composer = app(AgentComposeService::class);
 
     $result = $composer->compose($project, $agent);
 

--- a/tests/Feature/ComposeShareTest.php
+++ b/tests/Feature/ComposeShareTest.php
@@ -1,0 +1,153 @@
+<?php
+
+use App\Models\Agent;
+use App\Models\ComposeShareLink;
+use App\Models\Project;
+use App\Models\ProjectAgent;
+use App\Models\Skill;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::firstOrCreate(
+        ['email' => 'share@test.com'],
+        ['name' => 'Share Tester', 'password' => bcrypt('password')],
+    );
+
+    $this->project = Project::create([
+        'name' => 'Share Project',
+        'path' => '/tmp/share-project',
+        'providers' => ['claude'],
+        'owner_id' => $this->user->id,
+    ]);
+
+    $this->agent = Agent::create([
+        'name' => 'Share Agent',
+        'role' => 'reviewer',
+        'base_instructions' => 'You are a reviewer.',
+        'model' => 'claude-sonnet-4-6',
+        'objective_template' => 'Review code',
+        'success_criteria' => ['reviewed'],
+        'max_iterations' => 5,
+        'planning_mode' => 'plan_then_act',
+        'loop_condition' => 'goal_met',
+    ]);
+
+    ProjectAgent::create([
+        'project_id' => $this->project->id,
+        'agent_id' => $this->agent->id,
+        'is_enabled' => true,
+    ]);
+});
+
+it('creates a snapshot share link for a clean agent', function () {
+    $response = $this->actingAs($this->user)
+        ->postJson("/api/projects/{$this->project->id}/agents/{$this->agent->id}/compose/share", [
+            'depth' => 'full',
+            'is_snapshot' => true,
+            'expires_in_days' => 3,
+        ]);
+
+    $response->assertCreated()
+        ->assertJsonPath('data.is_snapshot', true);
+
+    $link = ComposeShareLink::where('created_by', $this->user->id)->first();
+    expect($link)->not->toBeNull()
+        ->and($link->snapshot_payload)->not->toBeNull()
+        ->and($link->expires_at)->not->toBeNull()
+        ->and($link->uuid)->toBeString();
+});
+
+it('refuses to create a share link when composed output contains a secret', function () {
+    $skill = Skill::create([
+        'project_id' => $this->project->id,
+        'name' => 'Leaky Skill',
+        'slug' => 'leaky',
+        'body' => 'API key sk-ant-abc1234567890abcdefghij for access.',
+    ]);
+
+    DB::table('agent_skill')->insert([
+        'project_id' => $this->project->id,
+        'agent_id' => $this->agent->id,
+        'skill_id' => $skill->id,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->postJson("/api/projects/{$this->project->id}/agents/{$this->agent->id}/compose/share", []);
+
+    $response->assertStatus(422)
+        ->assertJsonStructure(['error', 'secrets']);
+
+    expect(ComposeShareLink::count())->toBe(0);
+});
+
+it('serves a snapshot payload and increments access_count', function () {
+    $link = ComposeShareLink::create([
+        'project_id' => $this->project->id,
+        'agent_id' => $this->agent->id,
+        'depth' => 'full',
+        'created_by' => $this->user->id,
+        'expires_at' => now()->addDays(7),
+        'is_snapshot' => true,
+        'snapshot_payload' => [
+            'content' => "# Snapshot content\n",
+            'token_estimate' => 5,
+            'skill_count' => 0,
+            'target_model' => 'claude-sonnet-4-6',
+            'model_context_window' => 200000,
+            'skill_breakdown' => [],
+            'agent' => ['name' => 'Share Agent'],
+        ],
+    ]);
+
+    $this->getJson("/api/share/compose/{$link->uuid}")
+        ->assertOk()
+        ->assertJsonPath('data.content', "# Snapshot content\n")
+        ->assertJsonPath('data.target_model', 'claude-sonnet-4-6');
+
+    expect($link->fresh()->access_count)->toBe(1)
+        ->and($link->fresh()->last_accessed_at)->not->toBeNull();
+});
+
+it('returns 410 for expired share links', function () {
+    $link = ComposeShareLink::create([
+        'project_id' => $this->project->id,
+        'agent_id' => $this->agent->id,
+        'depth' => 'full',
+        'created_by' => $this->user->id,
+        'expires_at' => now()->subDay(),
+        'is_snapshot' => true,
+        'snapshot_payload' => ['content' => ''],
+    ]);
+
+    $this->getJson("/api/share/compose/{$link->uuid}")->assertStatus(410);
+});
+
+it('returns 404 for missing share links', function () {
+    $this->getJson('/api/share/compose/does-not-exist')->assertNotFound();
+});
+
+it('prevents non-creators from deleting share links', function () {
+    $link = ComposeShareLink::create([
+        'project_id' => $this->project->id,
+        'agent_id' => $this->agent->id,
+        'depth' => 'full',
+        'created_by' => $this->user->id,
+        'expires_at' => now()->addDays(7),
+        'is_snapshot' => true,
+        'snapshot_payload' => ['content' => ''],
+    ]);
+
+    $other = User::create([
+        'email' => 'other@test.com',
+        'name' => 'Other',
+        'password' => bcrypt('x'),
+    ]);
+
+    $this->actingAs($other)
+        ->deleteJson("/api/share/compose/{$link->uuid}")
+        ->assertForbidden();
+});

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -44,6 +44,7 @@ import { SharedMemory } from '@/pages/SharedMemory'
 import { Observability } from '@/pages/Observability'
 import { MobileApprovals } from '@/pages/MobileApprovals'
 import { Federation } from '@/pages/Federation'
+import { SharedCompose } from '@/pages/SharedCompose'
 
 function AppContent() {
   const { isOpen, close } = useCommandPalette()
@@ -56,6 +57,7 @@ function AppContent() {
         <Route path="/compare" element={<Compare />} />
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
+        <Route path="/share/compose/:uuid" element={<SharedCompose />} />
 
         {/* Setup wizard (full-screen, authenticated) */}
         <Route

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -656,12 +656,46 @@ export const bindAgentA2aAgents = (
   })
 
 // Agent Compose
-export const fetchAgentCompose = (projectId: number, agentId: number) =>
+export const fetchAgentCompose = (projectId: number, agentId: number, model?: string) =>
   api
     .get<ApiResponse<AgentComposed>>(
-      `/projects/${projectId}/agents/${agentId}/compose`,
+      `/projects/${projectId}/agents/${agentId}/compose${model ? `?model=${encodeURIComponent(model)}` : ''}`,
     )
     .then((r) => r.data.data)
+
+// Compose Share Links
+export interface ComposeShareLink {
+  uuid: string
+  url: string
+  expires_at: string
+  is_snapshot: boolean
+}
+
+export interface ComposeShareSecretIssue {
+  rule: string
+  message: string
+  line: number | null
+}
+
+export const createComposeShareLink = (
+  projectId: number,
+  agentId: number,
+  options: {
+    model?: string | null
+    depth?: 'index' | 'full' | 'deep'
+    is_snapshot?: boolean
+    expires_in_days?: number
+  } = {},
+) =>
+  api
+    .post<{ data: ComposeShareLink }>(
+      `/projects/${projectId}/agents/${agentId}/compose/share`,
+      options,
+    )
+    .then((r) => r.data.data)
+
+export const deleteComposeShareLink = (uuid: string) =>
+  api.delete(`/share/compose/${uuid}`)
 
 export const fetchAgentComposeStructured = (projectId: number, agentId: number) =>
   api

--- a/ui/src/components/agents/AgentComposePreview.tsx
+++ b/ui/src/components/agents/AgentComposePreview.tsx
@@ -1,16 +1,9 @@
-import { useState, useEffect } from 'react'
-import { X, Copy, Check, Loader2, AlertTriangle } from 'lucide-react'
-import { fetchAgentCompose } from '@/api/client'
+import { useState, useEffect, useMemo } from 'react'
+import { X, Copy, Check, Loader2, AlertTriangle, Share2, ChevronDown, ChevronRight } from 'lucide-react'
+import { fetchAgentCompose, fetchModels } from '@/api/client'
 import { Button } from '@/components/ui/button'
-import type { AgentComposed } from '@/types'
-
-const MODEL_LIMITS: Record<string, number> = {
-  'claude-sonnet-4-6': 200000,
-  'claude-opus-4-6': 200000,
-  'claude-haiku-4-5-20251001': 200000,
-  'gpt-5.4': 1048576,
-  'gpt-5-mini': 1048576,
-}
+import { ShareComposeModal } from '@/components/agents/ShareComposeModal'
+import type { AgentComposed, ModelGroup } from '@/types'
 
 const DEFAULT_LIMIT = 200000
 
@@ -26,13 +19,25 @@ export function AgentComposePreview({ projectId, agentId, agentName, onClose }: 
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
+  const [modelOverride, setModelOverride] = useState<string | null>(null)
+  const [modelGroups, setModelGroups] = useState<ModelGroup[]>([])
+  const [breakdownOpen, setBreakdownOpen] = useState(true)
+  const [hoverSlug, setHoverSlug] = useState<string | null>(null)
+  const [showShareModal, setShowShareModal] = useState(false)
 
   useEffect(() => {
-    fetchAgentCompose(projectId, agentId)
+    fetchModels()
+      .then(setModelGroups)
+      .catch(() => {})
+  }, [])
+
+  useEffect(() => {
+    setLoading(true)
+    fetchAgentCompose(projectId, agentId, modelOverride ?? undefined)
       .then(setComposed)
       .catch(() => setError('Failed to compose agent output'))
       .finally(() => setLoading(false))
-  }, [projectId, agentId])
+  }, [projectId, agentId, modelOverride])
 
   useEffect(() => {
     const handleEsc = (e: KeyboardEvent) => {
@@ -49,32 +54,44 @@ export function AgentComposePreview({ projectId, agentId, agentName, onClose }: 
     setTimeout(() => setCopied(false), 2000)
   }
 
+  const contextLimit = composed?.model_context_window || DEFAULT_LIMIT
   const tokenPercent = composed
-    ? Math.min((composed.token_estimate / DEFAULT_LIMIT) * 100, 100)
+    ? Math.min((composed.token_estimate / contextLimit) * 100, 100)
     : 0
+  const tokenWarning = composed && composed.token_estimate > contextLimit * 0.75
 
-  const tokenWarning = composed && composed.token_estimate > DEFAULT_LIMIT * 0.75
+  const highlighted = useMemo(() => {
+    if (!composed) return null
+    if (!hoverSlug) return { before: composed.content, match: '', after: '' }
+
+    const entry = composed.skill_breakdown.find((e) => e.slug === hoverSlug)
+    if (!entry) return { before: composed.content, match: '', after: '' }
+
+    return {
+      before: composed.content.slice(0, entry.starts_at_char),
+      match: composed.content.slice(entry.starts_at_char, entry.ends_at_char),
+      after: composed.content.slice(entry.ends_at_char),
+    }
+  }, [composed, hoverSlug])
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-foreground/30">
-      <div className="bg-background elevation-4 w-full max-w-4xl max-h-[90vh] flex flex-col">
+      <div className="bg-background elevation-4 w-full max-w-5xl max-h-[90vh] flex flex-col">
         {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b border-border">
-          <div className="flex items-center gap-3">
-            <div>
-              <h2 className="text-lg font-semibold tracking-tight">
+        <div className="flex items-center justify-between p-4 border-b border-border gap-4">
+          <div className="flex items-center gap-3 min-w-0">
+            <div className="min-w-0">
+              <h2 className="text-lg font-semibold tracking-tight truncate">
                 {agentName} — Composed Output
               </h2>
               {composed && (
-                <div className="flex items-center gap-3 mt-1">
+                <div className="flex items-center gap-3 mt-1 flex-wrap">
                   <span className="text-xs text-muted-foreground">
                     ~{composed.token_estimate.toLocaleString()} tokens
                   </span>
                   <span className="text-xs text-muted-foreground">
-                    {composed.skill_count} skill
-                    {composed.skill_count !== 1 ? 's' : ''} included
+                    {composed.skill_count} skill{composed.skill_count !== 1 ? 's' : ''}
                   </span>
-                  {/* Token budget bar */}
                   <div className="flex items-center gap-1.5">
                     <div className="w-24 h-1.5 bg-muted rounded-full overflow-hidden">
                       <div
@@ -89,7 +106,7 @@ export function AgentComposePreview({ projectId, agentId, agentName, onClose }: 
                       />
                     </div>
                     <span className="text-[10px] text-muted-foreground">
-                      {tokenPercent.toFixed(0)}%
+                      {tokenPercent.toFixed(0)}% of {contextLimit.toLocaleString()}
                     </span>
                   </div>
                   {tokenWarning && (
@@ -102,13 +119,23 @@ export function AgentComposePreview({ projectId, agentId, agentName, onClose }: 
               )}
             </div>
           </div>
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleCopy}
-              disabled={!composed}
+          <div className="flex items-center gap-2 shrink-0">
+            <select
+              value={modelOverride ?? ''}
+              onChange={(e) => setModelOverride(e.target.value || null)}
+              className="text-xs px-2 py-1.5 border border-input bg-background rounded"
+              title="Preview against a specific model"
             >
+              <option value="">Agent default</option>
+              {modelGroups.flatMap((group) =>
+                group.models.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.name}
+                  </option>
+                )),
+              )}
+            </select>
+            <Button variant="outline" size="sm" onClick={handleCopy} disabled={!composed}>
               {copied ? (
                 <>
                   <Check className="h-3.5 w-3.5 mr-1" />
@@ -121,6 +148,10 @@ export function AgentComposePreview({ projectId, agentId, agentName, onClose }: 
                 </>
               )}
             </Button>
+            <Button variant="outline" size="sm" onClick={() => setShowShareModal(true)} disabled={!composed}>
+              <Share2 className="h-3.5 w-3.5 mr-1" />
+              Share
+            </Button>
             <button
               onClick={onClose}
               className="p-1.5 hover:bg-muted transition-all duration-150"
@@ -131,26 +162,89 @@ export function AgentComposePreview({ projectId, agentId, agentName, onClose }: 
         </div>
 
         {/* Body */}
-        <div className="flex-1 overflow-y-auto">
-          {loading && (
-            <div className="flex items-center justify-center py-20">
-              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-            </div>
-          )}
+        <div className="flex-1 overflow-hidden grid grid-cols-1 lg:grid-cols-[1fr_260px]">
+          <div className="overflow-y-auto min-h-0">
+            {loading && (
+              <div className="flex items-center justify-center py-20">
+                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+              </div>
+            )}
+            {error && (
+              <div className="flex items-center justify-center py-20 text-muted-foreground">
+                <p className="text-sm">{error}</p>
+              </div>
+            )}
+            {composed && highlighted && (
+              <pre className="p-5 text-sm font-mono whitespace-pre-wrap leading-relaxed">
+                {highlighted.before}
+                {highlighted.match && (
+                  <span className="bg-primary/15 rounded px-0.5">{highlighted.match}</span>
+                )}
+                {highlighted.after}
+              </pre>
+            )}
+          </div>
 
-          {error && (
-            <div className="flex items-center justify-center py-20 text-muted-foreground">
-              <p className="text-sm">{error}</p>
-            </div>
-          )}
-
-          {composed && (
-            <pre className="p-5 text-sm font-mono whitespace-pre-wrap leading-relaxed">
-              {composed.content}
-            </pre>
+          {composed && composed.skill_breakdown.length > 0 && (
+            <aside className="border-t lg:border-t-0 lg:border-l border-border overflow-y-auto min-h-0 bg-muted/20">
+              <button
+                onClick={() => setBreakdownOpen(!breakdownOpen)}
+                className="w-full flex items-center gap-1.5 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground border-b border-border"
+              >
+                {breakdownOpen ? (
+                  <ChevronDown className="h-3 w-3" />
+                ) : (
+                  <ChevronRight className="h-3 w-3" />
+                )}
+                Skill breakdown ({composed.skill_breakdown.length})
+              </button>
+              {breakdownOpen && (
+                <ul>
+                  {composed.skill_breakdown.map((skill) => (
+                    <li
+                      key={skill.slug}
+                      onMouseEnter={() => setHoverSlug(skill.slug)}
+                      onMouseLeave={() => setHoverSlug(null)}
+                      className={`px-3 py-2 border-b border-border text-xs cursor-default transition-colors ${
+                        hoverSlug === skill.slug ? 'bg-primary/5' : ''
+                      }`}
+                    >
+                      <div className="font-medium text-foreground">{skill.name}</div>
+                      <div className="text-muted-foreground">
+                        {skill.token_estimate} tokens
+                      </div>
+                      {(skill.tuned_for_model || skill.last_validated_model) && (
+                        <div className="mt-1 flex flex-wrap gap-1">
+                          {skill.tuned_for_model && (
+                            <span className="font-mono px-1.5 py-0.5 bg-muted/60 rounded text-[10px]">
+                              tuned: {skill.tuned_for_model}
+                            </span>
+                          )}
+                          {skill.last_validated_model && (
+                            <span className="font-mono px-1.5 py-0.5 bg-muted/60 rounded text-[10px]">
+                              validated: {skill.last_validated_model}
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </aside>
           )}
         </div>
       </div>
+
+      {showShareModal && (
+        <ShareComposeModal
+          projectId={projectId}
+          agentId={agentId}
+          modelOverride={modelOverride}
+          depth="full"
+          onClose={() => setShowShareModal(false)}
+        />
+      )}
     </div>
   )
 }

--- a/ui/src/components/agents/ShareComposeModal.tsx
+++ b/ui/src/components/agents/ShareComposeModal.tsx
@@ -1,0 +1,178 @@
+import { useState } from 'react'
+import { X, Copy, Check, Loader2, AlertTriangle } from 'lucide-react'
+import axios from 'axios'
+import { createComposeShareLink } from '@/api/client'
+import { Button } from '@/components/ui/button'
+
+interface Props {
+  projectId: number
+  agentId: number
+  modelOverride: string | null
+  depth: 'index' | 'full' | 'deep'
+  onClose: () => void
+}
+
+interface SecretIssue {
+  rule: string
+  message: string
+  line: number | null
+}
+
+export function ShareComposeModal({ projectId, agentId, modelOverride, depth, onClose }: Props) {
+  const [expiresInDays, setExpiresInDays] = useState<number>(7)
+  const [isSnapshot, setIsSnapshot] = useState<boolean>(true)
+  const [creating, setCreating] = useState(false)
+  const [url, setUrl] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [secrets, setSecrets] = useState<SecretIssue[] | null>(null)
+
+  const handleCreate = async () => {
+    setCreating(true)
+    setError(null)
+    setSecrets(null)
+    try {
+      const link = await createComposeShareLink(projectId, agentId, {
+        model: modelOverride,
+        depth,
+        is_snapshot: isSnapshot,
+        expires_in_days: expiresInDays,
+      })
+      setUrl(link.url)
+    } catch (err) {
+      if (axios.isAxiosError(err) && err.response?.status === 422) {
+        setSecrets(err.response.data?.secrets ?? [])
+        setError(err.response.data?.error ?? 'Refused: output contains secrets')
+      } else {
+        setError('Failed to create share link')
+      }
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const handleCopy = async () => {
+    if (!url) return
+    await navigator.clipboard.writeText(url)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-foreground/30">
+      <div className="bg-background elevation-4 w-full max-w-md border border-border rounded">
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <h3 className="text-sm font-semibold">Share compose preview</h3>
+          <button onClick={onClose} className="p-1 hover:bg-muted rounded">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="p-4 space-y-4">
+          {url ? (
+            <div className="space-y-3">
+              <p className="text-sm text-foreground">Share link created.</p>
+              <div className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={url}
+                  readOnly
+                  className="flex-1 text-xs px-2 py-1.5 border border-input bg-muted/30 rounded"
+                />
+                <Button size="sm" variant="outline" onClick={handleCopy}>
+                  {copied ? (
+                    <>
+                      <Check className="h-3.5 w-3.5 mr-1" />
+                      Copied
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="h-3.5 w-3.5 mr-1" />
+                      Copy
+                    </>
+                  )}
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <>
+              <div>
+                <label className="text-xs font-medium text-muted-foreground">
+                  Expiry
+                </label>
+                <select
+                  value={expiresInDays}
+                  onChange={(e) => setExpiresInDays(parseInt(e.target.value))}
+                  className="mt-1 w-full px-2.5 py-1.5 text-sm border border-input bg-background rounded"
+                >
+                  <option value={1}>1 day</option>
+                  <option value={7}>7 days (default)</option>
+                  <option value={30}>30 days</option>
+                  <option value={90}>90 days</option>
+                </select>
+              </div>
+
+              <label className="flex items-start gap-2 text-xs cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={isSnapshot}
+                  onChange={(e) => setIsSnapshot(e.target.checked)}
+                  className="mt-0.5 rounded border-input"
+                />
+                <div>
+                  <div className="font-medium text-foreground">Snapshot (recommended)</div>
+                  <div className="text-muted-foreground">
+                    Freeze current content. Disable to re-render live on each view.
+                  </div>
+                </div>
+              </label>
+
+              {error && (
+                <div className="border border-destructive/40 bg-destructive/10 rounded p-3 space-y-2">
+                  <div className="flex items-start gap-2 text-xs text-destructive">
+                    <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                    <span className="font-medium">{error}</span>
+                  </div>
+                  {secrets && secrets.length > 0 && (
+                    <ul className="text-[11px] text-destructive/90 space-y-0.5 pl-5 list-disc">
+                      {secrets.map((s, i) => (
+                        <li key={i}>
+                          {s.message}
+                          {s.line !== null && ` (line ${s.line})`}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 p-4 border-t border-border">
+          {url ? (
+            <Button size="sm" onClick={onClose}>
+              Done
+            </Button>
+          ) : (
+            <>
+              <Button size="sm" variant="ghost" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button size="sm" onClick={handleCreate} disabled={creating}>
+                {creating ? (
+                  <>
+                    <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
+                    Creating…
+                  </>
+                ) : (
+                  'Create share link'
+                )}
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/pages/SharedCompose.tsx
+++ b/ui/src/pages/SharedCompose.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import axios from 'axios'
+
+interface SharedPayload {
+  uuid: string
+  content: string
+  token_estimate: number
+  target_model: string | null
+  model_context_window: number
+  skill_count: number
+  skill_breakdown: Array<{
+    slug: string
+    name: string
+    token_estimate: number
+    starts_at_char: number
+    ends_at_char: number
+    tuned_for_model: string | null
+    last_validated_model: string | null
+  }>
+  agent: { name: string; display_name?: string }
+  expires_at: string | null
+  is_snapshot: boolean
+}
+
+type LoadState =
+  | { status: 'loading' }
+  | { status: 'ok'; payload: SharedPayload }
+  | { status: 'expired' }
+  | { status: 'not_found' }
+  | { status: 'error'; message: string }
+
+export function SharedCompose() {
+  const { uuid } = useParams<{ uuid: string }>()
+  const [state, setState] = useState<LoadState>({ status: 'loading' })
+
+  useEffect(() => {
+    if (!uuid) return
+    axios
+      .get<{ data: SharedPayload }>(`/api/share/compose/${uuid}`)
+      .then((r) => setState({ status: 'ok', payload: r.data.data }))
+      .catch((err) => {
+        const code = err?.response?.status
+        if (code === 410) setState({ status: 'expired' })
+        else if (code === 404) setState({ status: 'not_found' })
+        else setState({ status: 'error', message: err?.message ?? 'Failed to load' })
+      })
+  }, [uuid])
+
+  if (state.status === 'loading') {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-background text-muted-foreground text-sm">
+        Loading…
+      </div>
+    )
+  }
+
+  if (state.status === 'expired') {
+    return (
+      <Message title="Share link expired" body="This shared preview is no longer available." />
+    )
+  }
+
+  if (state.status === 'not_found') {
+    return <Message title="Not found" body="This share link does not exist." />
+  }
+
+  if (state.status === 'error') {
+    return <Message title="Something went wrong" body={state.message} />
+  }
+
+  const { payload } = state
+  const usagePct = payload.model_context_window
+    ? Math.min(100, Math.round((payload.token_estimate / payload.model_context_window) * 100))
+    : null
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <header className="border-b border-border px-6 py-4">
+        <div className="max-w-5xl mx-auto flex items-center justify-between gap-4">
+          <div>
+            <h1 className="text-base font-semibold">
+              {payload.agent.display_name || payload.agent.name}
+            </h1>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Shared compose preview · {payload.is_snapshot ? 'snapshot' : 'live render'}
+              {payload.expires_at && ` · expires ${new Date(payload.expires_at).toLocaleDateString()}`}
+            </p>
+          </div>
+          <div className="text-right text-xs text-muted-foreground">
+            <div>{payload.target_model ?? 'no model'}</div>
+            <div>
+              {payload.token_estimate.toLocaleString()} tokens
+              {usagePct !== null && ` · ${usagePct}% of context`}
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-5xl mx-auto px-6 py-6 grid grid-cols-1 lg:grid-cols-[1fr_260px] gap-6">
+        <article>
+          <pre className="whitespace-pre-wrap text-sm leading-relaxed font-mono bg-muted/30 rounded p-4 border border-border">
+            {payload.content}
+          </pre>
+        </article>
+        <aside className="space-y-3">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Skill breakdown ({payload.skill_breakdown.length})
+          </h2>
+          {payload.skill_breakdown.length === 0 && (
+            <p className="text-xs text-muted-foreground">No skills in this compose.</p>
+          )}
+          <ul className="space-y-2">
+            {payload.skill_breakdown.map((skill) => (
+              <li key={skill.slug} className="text-xs border border-border rounded p-2">
+                <div className="font-medium text-foreground">{skill.name}</div>
+                <div className="text-muted-foreground">{skill.token_estimate} tokens</div>
+                {(skill.tuned_for_model || skill.last_validated_model) && (
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {skill.tuned_for_model && (
+                      <span className="font-mono px-1.5 py-0.5 bg-muted/60 rounded text-[10px]">
+                        tuned: {skill.tuned_for_model}
+                      </span>
+                    )}
+                    {skill.last_validated_model && (
+                      <span className="font-mono px-1.5 py-0.5 bg-muted/60 rounded text-[10px]">
+                        validated: {skill.last_validated_model}
+                      </span>
+                    )}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        </aside>
+      </main>
+    </div>
+  )
+}
+
+function Message({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-background">
+      <div className="text-center max-w-sm px-6">
+        <h1 className="text-lg font-semibold mb-2">{title}</h1>
+        <p className="text-sm text-muted-foreground">{body}</p>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -370,6 +370,16 @@ export interface SkillsShSkillDetail {
   frontmatter: Record<string, unknown>
 }
 
+export interface SkillBreakdownEntry {
+  slug: string
+  name: string
+  token_estimate: number
+  starts_at_char: number
+  ends_at_char: number
+  tuned_for_model: string | null
+  last_validated_model: string | null
+}
+
 export interface AgentComposed {
   content: string
   token_estimate: number
@@ -381,6 +391,9 @@ export interface AgentComposed {
     icon: string | null
   }
   skill_count: number
+  target_model: string | null
+  model_context_window: number
+  skill_breakdown: SkillBreakdownEntry[]
 }
 
 export interface AgentStructured {


### PR DESCRIPTION
## Summary

Phase 2 of the [Harness Engineering roadmap](https://github.com/eooo-io/orkestr/milestone/114). Shareable compose previews with model override, per-skill breakdown, and secret-scan gating.

## ⚠️ Security review requested

This PR introduces the **first unauthenticated content-returning API endpoint** beyond `/api/health` and the inbound GitHub webhook. Specifically:

- **`GET /api/share/compose/{uuid}`** (public, `throttle:30,1`)
- Returns snapshot payload when `is_snapshot=true`, else live re-renders
- `410 Gone` on expired; `404` on missing
- Increments `access_count` + `last_accessed_at` per hit

Defensive posture:
- Snapshot mode is the **default** (server doesn't re-compose on every public hit)
- Server-side secret scan via `PromptLinter` **before** creating a link — refused with `422` if any of its secret patterns fire
- `sanitizePayload()` also strips any `secret_*` keys from stored/re-rendered payloads
- `DELETE` requires the original creator (ownership check, not just auth)
- `POST` creation requires `org-role:editor`

Please validate:
- The rate limit is strict enough for the risk
- Snapshot payload contents don't carry anything else sensitive (e.g. skill bodies leaking confidential instructions into an unauthenticated URL)
- The `uuid` column has enough entropy (standard Laravel `Str::uuid()` → v4)

---

### #530 — Model override + skill breakdown

- `AgentComposeService::compose()` gains `?string $modelOverride` as its fourth arg
- Response includes `target_model`, `model_context_window`, `skill_breakdown[]`
- `renderWithOffsets()` records `starts_at_char`/`ends_at_char` per skill section
- `LLMProviderFactory::CONTEXT_WINDOWS` const extracted for shared lookup
- `AgentController::compose` plumbs `?model=` query param
- 4 new tests assert offset alignment + override behavior

### #531 — Share link backend

- Migration: `compose_share_links` (uuid, project_id, agent_id, model, depth, created_by, expires_at, last_accessed_at, access_count, is_snapshot, snapshot_payload longtext)
- `ComposeShareLink` model + `ComposeShareController`
- `POST /api/projects/{project}/agents/{agent}/compose/share` (editor+)
- `DELETE /api/share/compose/{uuid}` (owner only)
- Secret-scan gate via `PromptLinter::lint()` — 422 with `{error, secrets: [...]}` on detection
- Default snapshot + 7-day expiry
- 6 Pest tests covering gate, snapshot, expiry, 404/410, creator-only delete

### #532 — Public share route + SharedCompose page

- `GET /api/share/compose/{uuid}` — `throttle:30,1`, 410/404 handling, access tracking
- `ui/src/pages/SharedCompose.tsx` — minimal layout, no sidebar, no `AuthGuard`
- Route `/share/compose/:uuid` added in `App.tsx`
- Read-only render: content, token usage vs. context window, per-skill breakdown, expiry badge

### #533 — Compose preview UI upgrades

- `AgentComposePreview.tsx` — model-override dropdown (sourced from `fetchModels`), Share button, collapsible per-skill breakdown pane
- Hovering a breakdown entry highlights the corresponding slice of the content using char offsets
- Per-skill `tuned_for_model` / `last_validated_model` badges
- New `ShareComposeModal.tsx` — expiry select, snapshot toggle, inline secret-scan error state, copy URL flow
- `AgentComposed` type extended + `SkillBreakdownEntry` exported

## Test plan

- [x] Backend: 298/298 skill/eval/lint/agent/compose tests pass
- [x] UI: `tsc --noEmit` clean
- [x] Pest tests: 10 new (`AgentComposeServiceTest` +4, `ComposeShareTest` +6)
- [ ] Security review of public endpoint
- [ ] Manual: compose with model override → token meter updates against new model's context window
- [ ] Manual: create share link → copy URL → open in incognito → read-only view renders
- [ ] Manual: create skill with secret in body → create share → refused with inline error
- [ ] Manual: hover breakdown row → correct section highlighted in content
- [ ] Manual: delete share as non-creator → 403

## Dependencies

Unlocks Phase 3 (eval regression gates) — consumes `skill_breakdown` and the `last_validated_*` signal from Phase 1.

Closes #530
Closes #531
Closes #532
Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)