### PR TITLE
Phase 3: eval regression gates (#534–#539)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,9 @@ SESSION_DOMAIN=null
 
 BROADCAST_CONNECTION=log
 FILESYSTEM_DISK=local
+# QUEUE_CONNECTION must NOT be `sync` — eval-regression gates and agent
+# execution both dispatch long-running jobs (30s–10min) that would block
+# the HTTP request under sync. Use `database` or `redis`.
 QUEUE_CONNECTION=database
 
 CACHE_STORE=database

--- a/app/Http/Controllers/EvalSuiteController.php
+++ b/app/Http/Controllers/EvalSuiteController.php
@@ -6,7 +6,7 @@ use App\Models\Skill;
 use App\Models\SkillEvalPrompt;
 use App\Models\SkillEvalRun;
 use App\Models\SkillEvalSuite;
-use App\Services\LLM\LLMProviderFactory;
+use App\Jobs\RunEvalSuiteJob;
 use App\Services\PromptLinter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -126,14 +126,19 @@ class EvalSuiteController extends Controller
             'mode' => 'required|string|in:with_skill,without_skill,ab_test',
         ]);
 
+        $skill = $evalSuite->skill;
+        $currentVersion = $skill
+            ? $skill->versions()->orderByDesc('version_number')->first()
+            : null;
+
         $run = $evalSuite->runs()->create([
             'model' => $validated['model'],
             'mode' => $validated['mode'],
             'status' => 'pending',
+            'skill_version_id' => $currentVersion?->id,
         ]);
 
-        // Dispatch async job (placeholder — runs synchronously for now)
-        $this->executeRun($run);
+        RunEvalSuiteJob::dispatch($run->id);
 
         return response()->json(['data' => $run->fresh()], 201);
     }
@@ -213,87 +218,4 @@ class EvalSuiteController extends Controller
         ]);
     }
 
-    /**
-     * Execute an eval run synchronously (will be async via job later).
-     */
-    protected function executeRun(SkillEvalRun $run): void
-    {
-        $run->update(['status' => 'running', 'started_at' => now()]);
-
-        try {
-            $suite = $run->suite;
-            $skill = $suite->skill;
-            $prompts = $suite->prompts;
-            $factory = app(LLMProviderFactory::class);
-            $provider = $factory->make($run->model);
-
-            $results = [];
-            $totalScore = 0;
-
-            foreach ($prompts as $prompt) {
-                try {
-                    $messages = [['role' => 'user', 'content' => $prompt->prompt]];
-                    $withResponse = null;
-                    $withoutResponse = null;
-
-                    if ($run->mode === 'with_skill' || $run->mode === 'ab_test') {
-                        $withResponse = $provider->chat($messages, [
-                            'system' => $skill->body ?? '',
-                            'max_tokens' => $skill->max_tokens ?? 2048,
-                        ]);
-                    }
-
-                    if ($run->mode === 'without_skill' || $run->mode === 'ab_test') {
-                        $withoutResponse = $provider->chat($messages, [
-                            'max_tokens' => $skill->max_tokens ?? 2048,
-                        ]);
-                    }
-
-                    // Simple scoring: length and presence of expected behavior keywords
-                    $promptResult = [
-                        'prompt_id' => $prompt->id,
-                        'prompt_text' => $prompt->prompt,
-                        'score' => 70, // Default baseline
-                        'with_skill_response' => $withResponse ?? null,
-                        'without_skill_response' => $withoutResponse ?? null,
-                    ];
-
-                    if ($run->mode === 'ab_test') {
-                        $promptResult['winner'] = 'with_skill'; // placeholder
-                    }
-
-                    $results[] = $promptResult;
-                    $totalScore += $promptResult['score'];
-                } catch (\Throwable $e) {
-                    $results[] = [
-                        'prompt_id' => $prompt->id,
-                        'prompt_text' => $prompt->prompt,
-                        'score' => 0,
-                        'error' => $e->getMessage(),
-                    ];
-                }
-            }
-
-            $overall = count($results) > 0 ? $totalScore / count($results) : 0;
-
-            $run->update([
-                'status' => 'completed',
-                'overall_score' => $overall,
-                'results' => $results,
-                'completed_at' => now(),
-            ]);
-
-            $skill->update([
-                'last_validated_model' => $run->model,
-                'last_validated_at' => now(),
-                'last_validated_eval_run_id' => $run->id,
-            ]);
-        } catch (\Throwable $e) {
-            $run->update([
-                'status' => 'failed',
-                'results' => ['error' => $e->getMessage()],
-                'completed_at' => now(),
-            ]);
-        }
-    }
 }

--- a/app/Http/Controllers/SkillController.php
+++ b/app/Http/Controllers/SkillController.php
@@ -10,6 +10,7 @@ use App\Services\ManifestService;
 use App\Services\GitService;
 use App\Services\PromptLinter;
 use App\Services\SkillCompositionService;
+use App\Services\SkillEvalGateService;
 use App\Services\SkillStalenessService;
 use App\Services\WebhookDispatcher;
 use Illuminate\Http\JsonResponse;
@@ -158,11 +159,14 @@ class SkillController extends Controller
             $this->syncTags($skill, $validated['tags'] ?? []);
         }
 
-        $this->createVersion($skill);
+        $version = $this->createVersion($skill);
         $this->writeFile($skill->project, $skill);
         $this->dispatchWebhook('skill.updated', $skill->project, $skill);
 
-        return new SkillResource($skill->load('tags'));
+        $gateDecision = app(SkillEvalGateService::class)->evaluateSkillSave($skill, $version);
+
+        return (new SkillResource($skill->load('tags')))
+            ->additional(['gate_decision' => $gateDecision]);
     }
 
     public function lint(Skill $skill, PromptLinter $linter): JsonResponse
@@ -251,11 +255,11 @@ class SkillController extends Controller
         $skill->tags()->sync($tagIds);
     }
 
-    protected function createVersion(Skill $skill): void
+    protected function createVersion(Skill $skill): \App\Models\SkillVersion
     {
         $nextVersion = ($skill->versions()->max('version_number') ?? 0) + 1;
 
-        $skill->versions()->create([
+        return $skill->versions()->create([
             'version_number' => $nextVersion,
             'frontmatter' => [
                 'id' => $skill->slug,

--- a/app/Http/Controllers/SkillEvalGateController.php
+++ b/app/Http/Controllers/SkillEvalGateController.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Skill;
+use App\Models\SkillEvalGate;
+use App\Models\SkillEvalRun;
+use App\Services\SkillEvalGateService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class SkillEvalGateController extends Controller
+{
+    public function __construct(
+        protected SkillEvalGateService $gateService,
+    ) {}
+
+    public function show(Skill $skill): JsonResponse
+    {
+        $gate = $skill->evalGate ?? new SkillEvalGate([
+            'skill_id' => $skill->id,
+            'enabled' => false,
+            'required_suite_ids' => [],
+            'fail_threshold_delta' => -5.00,
+            'auto_run_on_save' => false,
+            'block_sync' => false,
+        ]);
+
+        return response()->json(['data' => $gate]);
+    }
+
+    public function update(Request $request, Skill $skill): JsonResponse
+    {
+        $validated = $request->validate([
+            'enabled' => 'boolean',
+            'required_suite_ids' => 'nullable|array',
+            'required_suite_ids.*' => 'integer|exists:skill_eval_suites,id',
+            'fail_threshold_delta' => 'nullable|numeric|between:-100,100',
+            'auto_run_on_save' => 'boolean',
+            'block_sync' => 'boolean',
+        ]);
+
+        $gate = $skill->evalGate()->firstOrNew();
+        $gate->fill($validated);
+        $gate->skill_id = $skill->id;
+        $gate->save();
+
+        return response()->json(['data' => $gate->fresh()]);
+    }
+
+    public function runNow(Skill $skill): JsonResponse
+    {
+        $version = $skill->versions()->orderByDesc('version_number')->first();
+
+        if (! $version) {
+            return response()->json([
+                'error' => 'No version snapshot exists — save the skill first.',
+            ], 422);
+        }
+
+        $decision = $this->gateService->evaluateSkillSave($skill, $version);
+
+        return response()->json(['data' => $decision]);
+    }
+
+    public function status(Skill $skill): JsonResponse
+    {
+        $gate = $skill->evalGate;
+
+        if (! $gate || empty($gate->required_suite_ids ?? [])) {
+            return response()->json([
+                'data' => [
+                    'enabled' => (bool) ($gate?->enabled),
+                    'runs' => [],
+                    'pending_count' => 0,
+                    'can_sync' => $this->gateService->canSync($skill),
+                ],
+            ]);
+        }
+
+        $model = $skill->tuned_for_model ?? $skill->model;
+        $suiteIds = $gate->required_suite_ids ?? [];
+        $runs = [];
+        $pendingCount = 0;
+
+        foreach ($suiteIds as $suiteId) {
+            $latest = SkillEvalRun::where('eval_suite_id', $suiteId)
+                ->when($model, fn ($q) => $q->where('model', $model))
+                ->orderByDesc('created_at')
+                ->first();
+
+            if (! $latest) continue;
+
+            if ($latest->status === 'pending' || $latest->status === 'running') {
+                $pendingCount++;
+            }
+
+            $baseline = $latest->baseline_run_id
+                ? SkillEvalRun::find($latest->baseline_run_id)
+                : null;
+
+            $delta = $baseline ? $this->gateService->computeDelta($latest, $baseline) : null;
+
+            $runs[] = [
+                'suite_id' => $suiteId,
+                'run_id' => $latest->id,
+                'status' => $latest->status,
+                'overall_score' => $latest->overall_score,
+                'delta' => $delta,
+            ];
+        }
+
+        return response()->json([
+            'data' => [
+                'enabled' => (bool) $gate->enabled,
+                'runs' => $runs,
+                'pending_count' => $pendingCount,
+                'can_sync' => $this->gateService->canSync($skill),
+            ],
+        ]);
+    }
+}

--- a/app/Jobs/RunEvalSuiteJob.php
+++ b/app/Jobs/RunEvalSuiteJob.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\SkillEvalRun;
+use App\Services\EvalScoring\ScorerFactory;
+use App\Services\LLM\LLMProviderFactory;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class RunEvalSuiteJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $timeout = 900;
+
+    public function __construct(public int $runId) {}
+
+    public function handle(
+        LLMProviderFactory $llmFactory,
+        ScorerFactory $scorerFactory,
+    ): void {
+        $run = SkillEvalRun::with(['suite.skill', 'suite.prompts'])->find($this->runId);
+
+        if (! $run || $run->status === 'completed' || $run->status === 'failed') {
+            return;
+        }
+
+        $run->update(['status' => 'running', 'started_at' => now()]);
+
+        try {
+            $suite = $run->suite;
+            $skill = $suite->skill;
+            $prompts = $suite->prompts;
+            $provider = $llmFactory->make($run->model);
+            $scorer = $scorerFactory->forSuite($suite);
+
+            $results = [];
+            $totalScore = 0;
+
+            foreach ($prompts as $prompt) {
+                try {
+                    $messages = [['role' => 'user', 'content' => $prompt->prompt]];
+                    $maxTokens = $skill->max_tokens ?? 2048;
+                    $withResponse = null;
+                    $withoutResponse = null;
+
+                    if ($run->mode === 'with_skill' || $run->mode === 'ab_test') {
+                        $withResponse = $this->extractText(
+                            $provider->chat($skill->body ?? '', $messages, $run->model, $maxTokens)
+                        );
+                    }
+
+                    if ($run->mode === 'without_skill' || $run->mode === 'ab_test') {
+                        $withoutResponse = $this->extractText(
+                            $provider->chat('', $messages, $run->model, $maxTokens)
+                        );
+                    }
+
+                    $scoredResponse = $withResponse ?? $withoutResponse ?? '';
+                    $grade = $scorer->score($prompt, $scoredResponse);
+
+                    $promptResult = [
+                        'prompt_id' => $prompt->id,
+                        'prompt_text' => $prompt->prompt,
+                        'score' => $grade['score'],
+                        'reasoning' => $grade['reasoning'],
+                        'signals' => $grade['signals'],
+                        'with_skill_response' => $withResponse,
+                        'without_skill_response' => $withoutResponse,
+                    ];
+
+                    if ($run->mode === 'ab_test') {
+                        $promptResult['winner'] = 'with_skill';
+                    }
+
+                    $results[] = $promptResult;
+                    $totalScore += $grade['score'];
+                } catch (\Throwable $e) {
+                    $results[] = [
+                        'prompt_id' => $prompt->id,
+                        'prompt_text' => $prompt->prompt,
+                        'score' => 0,
+                        'error' => $e->getMessage(),
+                    ];
+                }
+
+                $run->update(['results' => $results]);
+            }
+
+            $overall = count($results) > 0 ? $totalScore / count($results) : 0;
+
+            $run->update([
+                'status' => 'completed',
+                'overall_score' => $overall,
+                'results' => $results,
+                'completed_at' => now(),
+            ]);
+
+            $skill->update([
+                'last_validated_model' => $run->model,
+                'last_validated_at' => now(),
+                'last_validated_eval_run_id' => $run->id,
+            ]);
+        } catch (\Throwable $e) {
+            $run->update([
+                'status' => 'failed',
+                'results' => ['error' => $e->getMessage()],
+                'completed_at' => now(),
+            ]);
+        }
+    }
+
+    public function failed(\Throwable $e): void
+    {
+        SkillEvalRun::where('id', $this->runId)->update([
+            'status' => 'failed',
+            'results' => ['error' => $e->getMessage()],
+            'completed_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $response
+     */
+    protected function extractText(array $response): string
+    {
+        $text = '';
+        foreach (($response['content'] ?? []) as $block) {
+            if (($block['type'] ?? null) === 'text') {
+                $text .= $block['text'] ?? '';
+            }
+        }
+
+        return $text;
+    }
+}

--- a/app/Models/Skill.php
+++ b/app/Models/Skill.php
@@ -133,6 +133,11 @@ class Skill extends Model
         return $this->hasMany(SkillEvalSuite::class);
     }
 
+    public function evalGate(): \Illuminate\Database\Eloquent\Relations\HasOne
+    {
+        return $this->hasOne(SkillEvalGate::class);
+    }
+
     public function activeGotchas(): HasMany
     {
         return $this->hasMany(SkillGotcha::class)->whereNull('resolved_at');

--- a/app/Models/SkillEvalGate.php
+++ b/app/Models/SkillEvalGate.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SkillEvalGate extends Model
+{
+    protected $fillable = [
+        'skill_id',
+        'enabled',
+        'required_suite_ids',
+        'fail_threshold_delta',
+        'auto_run_on_save',
+        'block_sync',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'enabled' => 'boolean',
+            'required_suite_ids' => 'array',
+            'fail_threshold_delta' => 'decimal:2',
+            'auto_run_on_save' => 'boolean',
+            'block_sync' => 'boolean',
+        ];
+    }
+
+    public function skill(): BelongsTo
+    {
+        return $this->belongsTo(Skill::class);
+    }
+}

--- a/app/Models/SkillEvalRun.php
+++ b/app/Models/SkillEvalRun.php
@@ -8,8 +8,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class SkillEvalRun extends Model
 {
     protected $fillable = [
-        'eval_suite_id', 'model', 'mode', 'status',
-        'overall_score', 'results', 'started_at', 'completed_at',
+        'eval_suite_id', 'skill_version_id', 'baseline_run_id',
+        'model', 'mode', 'status',
+        'overall_score', 'delta_score',
+        'results', 'started_at', 'completed_at',
     ];
 
     protected function casts(): array
@@ -17,6 +19,7 @@ class SkillEvalRun extends Model
         return [
             'results' => 'array',
             'overall_score' => 'decimal:2',
+            'delta_score' => 'decimal:2',
             'started_at' => 'datetime',
             'completed_at' => 'datetime',
         ];
@@ -25,5 +28,15 @@ class SkillEvalRun extends Model
     public function suite(): BelongsTo
     {
         return $this->belongsTo(SkillEvalSuite::class, 'eval_suite_id');
+    }
+
+    public function skillVersion(): BelongsTo
+    {
+        return $this->belongsTo(SkillVersion::class, 'skill_version_id');
+    }
+
+    public function baselineRun(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'baseline_run_id');
     }
 }

--- a/app/Models/SkillEvalSuite.php
+++ b/app/Models/SkillEvalSuite.php
@@ -8,7 +8,11 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class SkillEvalSuite extends Model
 {
-    protected $fillable = ['skill_id', 'name', 'description'];
+    protected $fillable = ['skill_id', 'name', 'description', 'scorer'];
+
+    protected $attributes = [
+        'scorer' => 'keyword',
+    ];
 
     public function skill(): BelongsTo
     {

--- a/app/Services/EvalGateBlockedException.php
+++ b/app/Services/EvalGateBlockedException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\JsonResponse;
+
+class EvalGateBlockedException extends \RuntimeException
+{
+    /**
+     * @param  array<int, array<string, mixed>>  $blockedSkills
+     */
+    public function __construct(public readonly array $blockedSkills)
+    {
+        parent::__construct('Sync blocked by one or more skill eval gates.');
+    }
+
+    public function render(): JsonResponse
+    {
+        return response()->json([
+            'error' => $this->getMessage(),
+            'blocked_skills' => $this->blockedSkills,
+        ], 409);
+    }
+}

--- a/app/Services/EvalScoring/KeywordScorer.php
+++ b/app/Services/EvalScoring/KeywordScorer.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Services\EvalScoring;
+
+use App\Models\SkillEvalPrompt;
+
+/**
+ * Deterministic scoring pass: extracts expected keywords from a prompt's
+ * `expected_behavior` text and rewards their presence in the response.
+ * Cheap, reproducible, and good enough to gate regressions.
+ */
+class KeywordScorer implements ScorerInterface
+{
+    public function score(SkillEvalPrompt $prompt, string $response): array
+    {
+        $expected = trim((string) ($prompt->expected_behavior ?? ''));
+
+        if ($expected === '' || trim($response) === '') {
+            return [
+                'score' => 0,
+                'reasoning' => $expected === ''
+                    ? 'No expected_behavior defined; cannot score.'
+                    : 'Empty model response.',
+                'signals' => [
+                    'scorer' => 'keyword',
+                    'expected_keywords' => [],
+                    'matched' => [],
+                    'missing' => [],
+                ],
+            ];
+        }
+
+        $keywords = $this->extractKeywords($expected);
+
+        if (empty($keywords)) {
+            return [
+                'score' => 50,
+                'reasoning' => 'No usable keywords extracted from expected_behavior; returning neutral.',
+                'signals' => [
+                    'scorer' => 'keyword',
+                    'expected_keywords' => [],
+                    'matched' => [],
+                    'missing' => [],
+                ],
+            ];
+        }
+
+        $normalizedResponse = mb_strtolower($response);
+        $matched = [];
+        $missing = [];
+
+        foreach ($keywords as $keyword) {
+            if (mb_strpos($normalizedResponse, $keyword) !== false) {
+                $matched[] = $keyword;
+            } else {
+                $missing[] = $keyword;
+            }
+        }
+
+        $score = (int) round((count($matched) / count($keywords)) * 100);
+
+        return [
+            'score' => $score,
+            'reasoning' => sprintf(
+                'Matched %d of %d expected keywords.',
+                count($matched),
+                count($keywords),
+            ),
+            'signals' => [
+                'scorer' => 'keyword',
+                'expected_keywords' => $keywords,
+                'matched' => $matched,
+                'missing' => $missing,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function extractKeywords(string $text): array
+    {
+        $stopwords = [
+            'the', 'a', 'an', 'and', 'or', 'but', 'of', 'to', 'in', 'on',
+            'at', 'for', 'with', 'by', 'from', 'is', 'are', 'was', 'were',
+            'be', 'been', 'being', 'has', 'have', 'had', 'do', 'does',
+            'did', 'will', 'would', 'should', 'could', 'may', 'might',
+            'this', 'that', 'these', 'those', 'it', 'its', 'your',
+            'response', 'output', 'must', 'contain', 'mentions', 'include',
+        ];
+
+        $tokens = preg_split('/[^\p{L}\p{N}\-]+/u', mb_strtolower($text), -1, PREG_SPLIT_NO_EMPTY) ?: [];
+
+        return array_values(array_unique(array_filter(
+            $tokens,
+            fn (string $t) => mb_strlen($t) >= 3 && ! in_array($t, $stopwords, true),
+        )));
+    }
+}

--- a/app/Services/EvalScoring/LlmJudgeScorer.php
+++ b/app/Services/EvalScoring/LlmJudgeScorer.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Services\EvalScoring;
+
+use App\Models\SkillEvalPrompt;
+use App\Services\LLM\LLMProviderFactory;
+use JsonException;
+
+/**
+ * Opt-in LLM-as-judge scorer. Uses a second LLM call to grade the response
+ * against the prompt's `grading_criteria`. More expensive + non-deterministic;
+ * leave turned off by default.
+ */
+class LlmJudgeScorer implements ScorerInterface
+{
+    public const DEFAULT_JUDGE_MODEL = 'claude-sonnet-4-6';
+
+    public function __construct(
+        protected LLMProviderFactory $factory,
+    ) {}
+
+    public function score(SkillEvalPrompt $prompt, string $response): array
+    {
+        $criteria = $prompt->grading_criteria ?? [];
+        $criteriaText = is_array($criteria) ? implode("\n- ", $criteria) : (string) $criteria;
+
+        $judgeModel = config('eval.judge_model', self::DEFAULT_JUDGE_MODEL);
+        $provider = $this->factory->make($judgeModel);
+
+        $system = <<<'SYS'
+You are a strict grader. Given a user prompt, an expected behavior, and a model's response, output STRICT JSON:
+{"score": <0-100 integer>, "reasoning": "<one short sentence>"}
+No prose outside the JSON.
+SYS;
+
+        $userMsg = "Prompt:\n{$prompt->prompt}\n\nExpected behavior:\n" . ($prompt->expected_behavior ?? '—')
+            . "\n\nGrading criteria:\n- {$criteriaText}\n\nResponse to grade:\n{$response}";
+
+        try {
+            $response = $provider->chat(
+                $system,
+                [['role' => 'user', 'content' => $userMsg]],
+                $judgeModel,
+                300,
+            );
+        } catch (\Throwable $e) {
+            return [
+                'score' => 0,
+                'reasoning' => 'Judge call failed: ' . $e->getMessage(),
+                'signals' => ['scorer' => 'llm_judge', 'judge_error' => true, 'judge_model' => $judgeModel],
+            ];
+        }
+
+        $judgeOutput = $this->extractText($response);
+        $parsed = $this->parseJudgeJson($judgeOutput);
+        if ($parsed === null) {
+            return [
+                'score' => 0,
+                'reasoning' => 'Judge returned unparseable output.',
+                'signals' => [
+                    'scorer' => 'llm_judge',
+                    'judge_model' => $judgeModel,
+                    'raw_output' => mb_substr($judgeOutput, 0, 500),
+                ],
+            ];
+        }
+
+        return [
+            'score' => max(0, min(100, (int) ($parsed['score'] ?? 0))),
+            'reasoning' => (string) ($parsed['reasoning'] ?? ''),
+            'signals' => [
+                'scorer' => 'llm_judge',
+                'judge_model' => $judgeModel,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $response
+     */
+    protected function extractText(array $response): string
+    {
+        $text = '';
+        foreach (($response['content'] ?? []) as $block) {
+            if (($block['type'] ?? null) === 'text') {
+                $text .= $block['text'] ?? '';
+            }
+        }
+
+        return $text;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    protected function parseJudgeJson(string $output): ?array
+    {
+        $trimmed = trim($output);
+        if ($trimmed === '') {
+            return null;
+        }
+
+        if (preg_match('/\{.*\}/s', $trimmed, $matches)) {
+            $trimmed = $matches[0];
+        }
+
+        try {
+            $decoded = json_decode($trimmed, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return null;
+        }
+
+        return is_array($decoded) ? $decoded : null;
+    }
+}

--- a/app/Services/EvalScoring/ScorerFactory.php
+++ b/app/Services/EvalScoring/ScorerFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Services\EvalScoring;
+
+use App\Models\SkillEvalSuite;
+
+class ScorerFactory
+{
+    public const SCORER_KEYWORD = 'keyword';
+    public const SCORER_LLM_JUDGE = 'llm_judge';
+
+    public function __construct(
+        protected KeywordScorer $keyword,
+        protected LlmJudgeScorer $llmJudge,
+    ) {}
+
+    public function forSuite(SkillEvalSuite $suite): ScorerInterface
+    {
+        return match ($suite->scorer) {
+            self::SCORER_LLM_JUDGE => $this->llmJudge,
+            default => $this->keyword,
+        };
+    }
+}

--- a/app/Services/EvalScoring/ScorerInterface.php
+++ b/app/Services/EvalScoring/ScorerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Services\EvalScoring;
+
+use App\Models\SkillEvalPrompt;
+
+interface ScorerInterface
+{
+    /**
+     * Grade a model's response against a prompt's expectations.
+     *
+     * @return array{score: int, reasoning: string, signals: array<string, mixed>}
+     */
+    public function score(SkillEvalPrompt $prompt, string $response): array;
+}

--- a/app/Services/ProviderSyncService.php
+++ b/app/Services/ProviderSyncService.php
@@ -30,7 +30,41 @@ class ProviderSyncService
         protected AgentComposeService $composeService,
         protected SkillCompositionService $compositionService,
         protected TemplateResolver $templateResolver,
+        protected SkillEvalGateService $gateService,
     ) {}
+
+    /**
+     * Thrown when a skill's eval gate blocks sync.
+     */
+    public function assertCanSync(Project $project): void
+    {
+        $project->loadMissing(['skills.evalGate']);
+        $blocked = [];
+
+        foreach ($project->skills as $skill) {
+            if (! $this->gateService->canSync($skill)) {
+                $gate = $skill->evalGate;
+                $latest = null;
+                if ($gate && ! empty($gate->required_suite_ids ?? [])) {
+                    $latest = \App\Models\SkillEvalRun::whereIn('eval_suite_id', $gate->required_suite_ids)
+                        ->orderByDesc('completed_at')
+                        ->first();
+                }
+
+                $blocked[] = [
+                    'skill_id' => $skill->id,
+                    'skill_slug' => $skill->slug,
+                    'skill_name' => $skill->name,
+                    'last_delta' => $latest?->delta_score,
+                    'last_run_id' => $latest?->id,
+                ];
+            }
+        }
+
+        if (! empty($blocked)) {
+            throw new EvalGateBlockedException($blocked);
+        }
+    }
 
     public function getDriver(string $slug): ProviderDriverInterface
     {
@@ -45,6 +79,8 @@ class ProviderSyncService
 
     public function syncProject(Project $project): void
     {
+        $this->assertCanSync($project);
+
         $project->loadMissing(['providers', 'skills.tags']);
         $skills = $project->skills;
 

--- a/app/Services/SkillEvalGateService.php
+++ b/app/Services/SkillEvalGateService.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace App\Services;
+
+use App\Jobs\RunEvalSuiteJob;
+use App\Models\Skill;
+use App\Models\SkillEvalGate;
+use App\Models\SkillEvalRun;
+use App\Models\SkillEvalSuite;
+use App\Models\SkillVersion;
+
+class SkillEvalGateService
+{
+    /**
+     * Decide whether a save should trigger eval runs, and if so enqueue them.
+     * Returns the decision payload for the SPA to render a banner/modal.
+     *
+     * @return array{enqueued_run_ids: array<int, int>, baseline_info: array<int, array<string, mixed>>, est_duration_seconds: int, reason: string}
+     */
+    public function evaluateSkillSave(Skill $skill, SkillVersion $newVersion): array
+    {
+        $gate = $skill->evalGate;
+        $reason = 'no_gate';
+
+        if (! $gate || ! $gate->enabled || ! $gate->auto_run_on_save) {
+            return [
+                'enqueued_run_ids' => [],
+                'baseline_info' => [],
+                'est_duration_seconds' => 0,
+                'reason' => $gate ? 'disabled' : 'no_gate',
+            ];
+        }
+
+        $suiteIds = $gate->required_suite_ids ?? [];
+        if (empty($suiteIds)) {
+            return [
+                'enqueued_run_ids' => [],
+                'baseline_info' => [],
+                'est_duration_seconds' => 0,
+                'reason' => 'no_required_suites',
+            ];
+        }
+
+        $suites = SkillEvalSuite::whereIn('id', $suiteIds)
+            ->where('skill_id', $skill->id)
+            ->with('prompts')
+            ->get();
+
+        $model = $skill->tuned_for_model ?? $skill->model;
+        if (! $model) {
+            return [
+                'enqueued_run_ids' => [],
+                'baseline_info' => [],
+                'est_duration_seconds' => 0,
+                'reason' => 'no_target_model',
+            ];
+        }
+
+        $enqueued = [];
+        $baselineInfo = [];
+        $estSeconds = 0;
+
+        foreach ($suites as $suite) {
+            $baseline = $this->findBaselineFor($skill, $suite, $model);
+
+            $run = $suite->runs()->create([
+                'model' => $model,
+                'mode' => 'with_skill',
+                'status' => 'pending',
+                'skill_version_id' => $newVersion->id,
+                'baseline_run_id' => $baseline?->id,
+            ]);
+
+            RunEvalSuiteJob::dispatch($run->id);
+            $enqueued[] = $run->id;
+
+            $baselineInfo[] = [
+                'suite_id' => $suite->id,
+                'suite_name' => $suite->name,
+                'run_id' => $run->id,
+                'baseline_run_id' => $baseline?->id,
+                'baseline_score' => $baseline?->overall_score,
+            ];
+
+            $estSeconds += max(5, $suite->prompts->count() * 6);
+        }
+
+        return [
+            'enqueued_run_ids' => $enqueued,
+            'baseline_info' => $baselineInfo,
+            'est_duration_seconds' => $estSeconds,
+            'reason' => 'dispatched',
+        ];
+    }
+
+    /**
+     * Baseline = most recent completed run for (suite, model), regardless
+     * of the version it ran against. Uses last-known-good as the anchor
+     * rather than "prior version" so revalidating the same version twice
+     * doesn't accidentally zero out the delta.
+     */
+    public function findBaselineFor(Skill $skill, SkillEvalSuite $suite, string $model): ?SkillEvalRun
+    {
+        return SkillEvalRun::query()
+            ->where('eval_suite_id', $suite->id)
+            ->where('model', $model)
+            ->where('status', 'completed')
+            ->orderByDesc('completed_at')
+            ->first();
+    }
+
+    /**
+     * Compute per-prompt + overall deltas between a current run and a baseline.
+     *
+     * @return array{overall_delta: float, per_prompt: array<int, array{prompt_id: int|null, current: int, baseline: int|null, delta: int|null}>}
+     */
+    public function computeDelta(SkillEvalRun $current, SkillEvalRun $baseline): array
+    {
+        $currentScore = (float) ($current->overall_score ?? 0);
+        $baselineScore = (float) ($baseline->overall_score ?? 0);
+
+        $baselineByPrompt = [];
+        foreach (($baseline->results ?? []) as $result) {
+            $pid = $result['prompt_id'] ?? null;
+            if ($pid !== null) {
+                $baselineByPrompt[$pid] = (int) ($result['score'] ?? 0);
+            }
+        }
+
+        $perPrompt = [];
+        foreach (($current->results ?? []) as $result) {
+            $pid = $result['prompt_id'] ?? null;
+            $currScore = (int) ($result['score'] ?? 0);
+            $baseScore = $pid !== null ? ($baselineByPrompt[$pid] ?? null) : null;
+            $perPrompt[] = [
+                'prompt_id' => $pid,
+                'current' => $currScore,
+                'baseline' => $baseScore,
+                'delta' => $baseScore !== null ? $currScore - $baseScore : null,
+            ];
+        }
+
+        return [
+            'overall_delta' => round($currentScore - $baselineScore, 2),
+            'per_prompt' => $perPrompt,
+        ];
+    }
+
+    /**
+     * Can this skill be synced? If the gate is configured to block sync,
+     * the most recent run for each required suite must be either completed
+     * with delta ≥ threshold, or not yet run (allow-by-default for first sync).
+     */
+    public function canSync(Skill $skill): bool
+    {
+        $gate = $skill->evalGate;
+        if (! $gate || ! $gate->enabled || ! $gate->block_sync) {
+            return true;
+        }
+
+        $suiteIds = $gate->required_suite_ids ?? [];
+        if (empty($suiteIds)) {
+            return true;
+        }
+
+        $threshold = (float) $gate->fail_threshold_delta;
+        $model = $skill->tuned_for_model ?? $skill->model;
+        if (! $model) {
+            return true;
+        }
+
+        foreach ($suiteIds as $suiteId) {
+            $suite = SkillEvalSuite::find($suiteId);
+            if (! $suite) continue;
+
+            $latest = SkillEvalRun::where('eval_suite_id', $suiteId)
+                ->where('model', $model)
+                ->whereIn('status', ['completed', 'failed'])
+                ->orderByDesc('completed_at')
+                ->first();
+
+            if (! $latest || $latest->status === 'failed') {
+                return false;
+            }
+
+            if ($latest->delta_score !== null && (float) $latest->delta_score < $threshold) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/database/migrations/2026_04_18_181651_add_scorer_to_skill_eval_suites.php
+++ b/database/migrations/2026_04_18_181651_add_scorer_to_skill_eval_suites.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('skill_eval_suites', function (Blueprint $table) {
+            $table->string('scorer', 32)->default('keyword')->after('description');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('skill_eval_suites', function (Blueprint $table) {
+            $table->dropColumn('scorer');
+        });
+    }
+};

--- a/database/migrations/2026_04_18_181652_add_version_link_to_skill_eval_runs.php
+++ b/database/migrations/2026_04_18_181652_add_version_link_to_skill_eval_runs.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('skill_eval_runs', function (Blueprint $table) {
+            $table->foreignId('skill_version_id')
+                ->nullable()
+                ->after('eval_suite_id')
+                ->constrained('skill_versions')
+                ->nullOnDelete();
+
+            $table->foreignId('baseline_run_id')
+                ->nullable()
+                ->after('skill_version_id')
+                ->constrained('skill_eval_runs')
+                ->nullOnDelete();
+
+            $table->decimal('delta_score', 5, 2)->nullable()->after('overall_score');
+
+            $table->index(['skill_version_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('skill_eval_runs', function (Blueprint $table) {
+            $table->dropIndex(['skill_version_id', 'status']);
+            $table->dropConstrainedForeignId('baseline_run_id');
+            $table->dropConstrainedForeignId('skill_version_id');
+            $table->dropColumn('delta_score');
+        });
+    }
+};

--- a/database/migrations/2026_04_18_181653_create_skill_eval_gates_table.php
+++ b/database/migrations/2026_04_18_181653_create_skill_eval_gates_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('skill_eval_gates', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('skill_id')->unique()->constrained()->cascadeOnDelete();
+            $table->boolean('enabled')->default(false);
+            $table->json('required_suite_ids')->nullable();
+            $table->decimal('fail_threshold_delta', 5, 2)->default(-5.00);
+            $table->boolean('auto_run_on_save')->default(false);
+            $table->boolean('block_sync')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('skill_eval_gates');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\EvalSuiteController;
 use App\Http\Controllers\GotchaController;
 use App\Http\Controllers\SkillAssetController;
 use App\Http\Controllers\SkillController;
+use App\Http\Controllers\SkillEvalGateController;
 use App\Http\Controllers\SkillGenerateController;
 use App\Http\Controllers\SkillTestController;
 use App\Http\Controllers\SkillVariableController;
@@ -159,6 +160,12 @@ Route::middleware('auth:web')->group(function () {
     Route::get('/skills/{skill}/lint', [SkillController::class, 'lint']);
     Route::get('/skills/{skill}/staleness', [SkillController::class, 'staleness']);
     Route::put('/skills/{skill}/staleness', [SkillController::class, 'updateStaleness'])->middleware('org-role:editor');
+
+    // Eval gate per skill
+    Route::get('/skills/{skill}/eval-gate', [SkillEvalGateController::class, 'show']);
+    Route::put('/skills/{skill}/eval-gate', [SkillEvalGateController::class, 'update'])->middleware('org-role:editor');
+    Route::post('/skills/{skill}/eval-gate/run-now', [SkillEvalGateController::class, 'runNow'])->middleware('org-role:editor');
+    Route::get('/skills/{skill}/eval-gate/status', [SkillEvalGateController::class, 'status']);
 
     // Skill Assets (folder-based skills)
     Route::get('/skills/{skill}/assets', [SkillAssetController::class, 'index']);

--- a/tests/Feature/EvalJobTest.php
+++ b/tests/Feature/EvalJobTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use App\Jobs\RunEvalSuiteJob;
+use App\Models\Project;
+use App\Models\Skill;
+use App\Models\SkillEvalPrompt;
+use App\Models\SkillEvalRun;
+use App\Models\SkillEvalSuite;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::firstOrCreate(
+        ['email' => 'eval@test.com'],
+        ['name' => 'Eval Tester', 'password' => bcrypt('password')],
+    );
+
+    $this->project = Project::create([
+        'name' => 'Eval Project',
+        'path' => '/tmp/eval-project',
+        'providers' => ['claude'],
+        'owner_id' => $this->user->id,
+    ]);
+
+    $this->skill = Skill::create([
+        'project_id' => $this->project->id,
+        'name' => 'Eval Skill',
+        'slug' => 'eval-skill',
+        'body' => 'You are a helper.',
+        'max_tokens' => 512,
+    ]);
+
+    $this->suite = SkillEvalSuite::create([
+        'skill_id' => $this->skill->id,
+        'name' => 'Suite A',
+        'scorer' => 'keyword',
+    ]);
+
+    SkillEvalPrompt::create([
+        'eval_suite_id' => $this->suite->id,
+        'prompt' => 'Summarize the doc.',
+        'expected_behavior' => 'Mention summary and bullets.',
+        'sort_order' => 1,
+    ]);
+});
+
+it('creates a pending run and dispatches RunEvalSuiteJob when triggered', function () {
+    Queue::fake();
+
+    $response = $this->actingAs($this->user)->postJson(
+        "/api/eval-suites/{$this->suite->id}/run",
+        ['model' => 'claude-sonnet-4-6', 'mode' => 'with_skill'],
+    );
+
+    $response->assertCreated();
+
+    $run = SkillEvalRun::where('eval_suite_id', $this->suite->id)->first();
+    expect($run)->not->toBeNull()
+        ->and($run->status)->toBe('pending');
+
+    Queue::assertPushed(RunEvalSuiteJob::class, fn ($job) => $job->runId === $run->id);
+});
+
+it('captures skill_version_id at dispatch time when a version exists', function () {
+    Queue::fake();
+
+    $version = $this->skill->versions()->create([
+        'version_number' => 1,
+        'frontmatter' => [],
+        'body' => $this->skill->body,
+        'saved_at' => now(),
+    ]);
+
+    $this->actingAs($this->user)->postJson(
+        "/api/eval-suites/{$this->suite->id}/run",
+        ['model' => 'claude-sonnet-4-6', 'mode' => 'with_skill'],
+    )->assertCreated();
+
+    $run = SkillEvalRun::where('eval_suite_id', $this->suite->id)->first();
+    expect($run->skill_version_id)->toBe($version->id);
+});
+
+it('completes the run and captures per-prompt errors when the provider fails', function () {
+    $run = SkillEvalRun::create([
+        'eval_suite_id' => $this->suite->id,
+        'model' => 'nonexistent-model-xxx',
+        'mode' => 'with_skill',
+        'status' => 'pending',
+    ]);
+
+    (new RunEvalSuiteJob($run->id))->handle(
+        app(\App\Services\LLM\LLMProviderFactory::class),
+        app(\App\Services\EvalScoring\ScorerFactory::class),
+    );
+
+    $fresh = $run->fresh();
+    expect($fresh->status)->toBe('completed')
+        ->and($fresh->results)->not->toBeNull()
+        ->and($fresh->results[0])->toHaveKey('error');
+});
+
+it('short-circuits on an already-finished run', function () {
+    $run = SkillEvalRun::create([
+        'eval_suite_id' => $this->suite->id,
+        'model' => 'claude-sonnet-4-6',
+        'mode' => 'with_skill',
+        'status' => 'completed',
+        'completed_at' => now(),
+    ]);
+
+    (new RunEvalSuiteJob($run->id))->handle(
+        app(\App\Services\LLM\LLMProviderFactory::class),
+        app(\App\Services\EvalScoring\ScorerFactory::class),
+    );
+
+    expect($run->fresh()->status)->toBe('completed');
+});

--- a/tests/Feature/EvalScoringTest.php
+++ b/tests/Feature/EvalScoringTest.php
@@ -1,0 +1,147 @@
+<?php
+
+use App\Models\SkillEvalPrompt;
+use App\Services\EvalScoring\KeywordScorer;
+use App\Services\EvalScoring\LlmJudgeScorer;
+use App\Services\EvalScoring\ScorerFactory;
+use App\Services\LLM\LLMProviderFactory;
+use App\Services\LLM\LLMProviderInterface;
+
+function makePrompt(string $expected = '', string $promptText = 'Tell me about widgets'): SkillEvalPrompt
+{
+    return new SkillEvalPrompt([
+        'id' => 1,
+        'eval_suite_id' => 1,
+        'prompt' => $promptText,
+        'expected_behavior' => $expected,
+        'grading_criteria' => ['Must mention widgets'],
+        'sort_order' => 1,
+    ]);
+}
+
+it('KeywordScorer: returns 0 when expected_behavior is empty', function () {
+    $scorer = new KeywordScorer();
+    $result = $scorer->score(makePrompt(''), 'any response');
+
+    expect($result['score'])->toBe(0)
+        ->and($result['signals']['scorer'])->toBe('keyword');
+});
+
+it('KeywordScorer: returns 0 when response is empty', function () {
+    $scorer = new KeywordScorer();
+    $result = $scorer->score(makePrompt('Must mention summarization and bullets'), '');
+
+    expect($result['score'])->toBe(0);
+});
+
+it('KeywordScorer: returns 100 when all expected keywords present', function () {
+    $scorer = new KeywordScorer();
+    $result = $scorer->score(
+        makePrompt('Response must include widgets and gears'),
+        'The widgets interlock with the gears precisely.',
+    );
+
+    expect($result['score'])->toBe(100)
+        ->and($result['signals']['matched'])->toContain('widgets')
+        ->and($result['signals']['matched'])->toContain('gears')
+        ->and($result['signals']['missing'])->toBeEmpty();
+});
+
+it('KeywordScorer: returns partial score when some keywords missing', function () {
+    $scorer = new KeywordScorer();
+    $result = $scorer->score(
+        makePrompt('Response must mention widgets gears sprockets cogs'),
+        'The widgets and gears are here.',
+    );
+
+    expect($result['score'])->toBeGreaterThan(0)
+        ->and($result['score'])->toBeLessThan(100)
+        ->and($result['signals']['missing'])->not->toBeEmpty();
+});
+
+it('KeywordScorer: stopwords are ignored', function () {
+    $scorer = new KeywordScorer();
+    // 'the', 'and', 'of' are stopwords, leaving just 'widgets'
+    $result = $scorer->score(
+        makePrompt('The response must have widgets and the like of it'),
+        'widgets are mentioned.',
+    );
+
+    expect($result['signals']['expected_keywords'])->toContain('widgets')
+        ->and($result['signals']['expected_keywords'])->not->toContain('the')
+        ->and($result['signals']['expected_keywords'])->not->toContain('and');
+});
+
+function fakeProvider(string $textResponse): LLMProviderInterface
+{
+    return new class ($textResponse) implements LLMProviderInterface {
+        public function __construct(protected string $response) {}
+
+        public function chat(string $systemPrompt, array $messages, string $model, int $maxTokens, array $tools = []): array
+        {
+            return [
+                'content' => [['type' => 'text', 'text' => $this->response]],
+                'stop_reason' => 'end_turn',
+                'usage' => ['input_tokens' => 0, 'output_tokens' => 0],
+            ];
+        }
+
+        public function stream(string $systemPrompt, array $messages, string $model, int $maxTokens): \Generator
+        {
+            yield ['type' => 'text', 'text' => $this->response];
+            yield ['type' => 'done'];
+        }
+
+        public function models(): array
+        {
+            return [];
+        }
+    };
+}
+
+function fakeFactory(LLMProviderInterface $provider): LLMProviderFactory
+{
+    return new class ($provider) extends LLMProviderFactory {
+        public function __construct(protected LLMProviderInterface $provider) {}
+
+        public function make(string $model): LLMProviderInterface
+        {
+            return $this->provider;
+        }
+    };
+}
+
+it('LlmJudgeScorer: parses valid JSON judge output', function () {
+    $factory = fakeFactory(fakeProvider('{"score": 85, "reasoning": "Clear match."}'));
+    $scorer = new LlmJudgeScorer($factory);
+
+    $result = $scorer->score(makePrompt('Mention widgets'), 'widgets and gears');
+
+    expect($result['score'])->toBe(85)
+        ->and($result['reasoning'])->toBe('Clear match.')
+        ->and($result['signals']['scorer'])->toBe('llm_judge');
+});
+
+it('LlmJudgeScorer: handles unparseable judge output gracefully', function () {
+    $factory = fakeFactory(fakeProvider('not even close to JSON'));
+    $scorer = new LlmJudgeScorer($factory);
+
+    $result = $scorer->score(makePrompt('Mention widgets'), 'some response');
+
+    expect($result['score'])->toBe(0)
+        ->and($result['reasoning'])->toContain('unparseable');
+});
+
+it('ScorerFactory resolves keyword by default', function () {
+    $factory = app(ScorerFactory::class);
+    $suite = new \App\Models\SkillEvalSuite(['scorer' => 'keyword']);
+
+    expect($factory->forSuite($suite))->toBeInstanceOf(KeywordScorer::class);
+});
+
+it('ScorerFactory resolves llm_judge when suite asks for it', function () {
+    $factory = app(ScorerFactory::class);
+    $suite = new \App\Models\SkillEvalSuite(['scorer' => 'llm_judge']);
+
+    expect($factory->forSuite($suite))->toBeInstanceOf(LlmJudgeScorer::class);
+});

--- a/tests/Feature/SkillEvalGateIntegrationTest.php
+++ b/tests/Feature/SkillEvalGateIntegrationTest.php
@@ -1,0 +1,130 @@
+<?php
+
+use App\Jobs\RunEvalSuiteJob;
+use App\Models\Project;
+use App\Models\Skill;
+use App\Models\SkillEvalGate;
+use App\Models\SkillEvalPrompt;
+use App\Models\SkillEvalRun;
+use App\Models\SkillEvalSuite;
+use App\Models\User;
+use App\Services\EvalGateBlockedException;
+use App\Services\ProviderSyncService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::firstOrCreate(
+        ['email' => 'gateint@test.com'],
+        ['name' => 'Gate Int', 'password' => bcrypt('password')],
+    );
+
+    $this->project = Project::create([
+        'name' => 'Gate Int Project',
+        'path' => '/tmp/gate-int',
+        'providers' => ['claude'],
+        'owner_id' => $this->user->id,
+    ]);
+
+    $this->skill = Skill::create([
+        'project_id' => $this->project->id,
+        'name' => 'Critical Skill',
+        'slug' => 'critical-skill',
+        'body' => 'Be careful.',
+        'model' => 'claude-sonnet-4-6',
+        'tuned_for_model' => 'claude-sonnet-4-6',
+    ]);
+
+    $this->suite = SkillEvalSuite::create([
+        'skill_id' => $this->skill->id,
+        'name' => 'Main',
+    ]);
+
+    SkillEvalPrompt::create([
+        'eval_suite_id' => $this->suite->id,
+        'prompt' => 'Say hi.',
+        'expected_behavior' => 'Must greet.',
+        'sort_order' => 1,
+    ]);
+});
+
+it('save triggers gate decision when auto_run_on_save is enabled', function () {
+    Queue::fake();
+
+    SkillEvalGate::create([
+        'skill_id' => $this->skill->id,
+        'enabled' => true,
+        'required_suite_ids' => [$this->suite->id],
+        'auto_run_on_save' => true,
+        'block_sync' => false,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->putJson("/api/skills/{$this->skill->id}", ['body' => 'Updated body.']);
+
+    $response->assertOk()
+        ->assertJsonPath('gate_decision.reason', 'dispatched');
+
+    Queue::assertPushed(RunEvalSuiteJob::class);
+});
+
+it('save returns no_gate when no gate configured', function () {
+    $response = $this->actingAs($this->user)
+        ->putJson("/api/skills/{$this->skill->id}", ['body' => 'Updated body.']);
+
+    $response->assertOk()
+        ->assertJsonPath('gate_decision.reason', 'no_gate');
+});
+
+it('canSync blocks project sync when a skill has a failing delta', function () {
+    SkillEvalGate::create([
+        'skill_id' => $this->skill->id,
+        'enabled' => true,
+        'required_suite_ids' => [$this->suite->id],
+        'fail_threshold_delta' => -5.00,
+        'block_sync' => true,
+    ]);
+
+    SkillEvalRun::create([
+        'eval_suite_id' => $this->suite->id,
+        'model' => 'claude-sonnet-4-6',
+        'mode' => 'with_skill',
+        'status' => 'completed',
+        'overall_score' => 60,
+        'delta_score' => -10.00,
+        'completed_at' => now(),
+    ]);
+
+    $service = app(ProviderSyncService::class);
+
+    expect(fn () => $service->assertCanSync($this->project->fresh()))
+        ->toThrow(EvalGateBlockedException::class);
+});
+
+it('EvalGateBlockedException renders a 409 with blocked skill details', function () {
+    $exception = new EvalGateBlockedException([
+        [
+            'skill_id' => 7,
+            'skill_slug' => 'foo',
+            'skill_name' => 'Foo',
+            'last_delta' => -8.50,
+            'last_run_id' => 42,
+        ],
+    ]);
+
+    $response = $exception->render();
+
+    expect($response->getStatusCode())->toBe(409);
+    expect(json_decode($response->getContent(), true))->toMatchArray([
+        'error' => 'Sync blocked by one or more skill eval gates.',
+        'blocked_skills' => [[
+            'skill_id' => 7,
+            'skill_slug' => 'foo',
+            'skill_name' => 'Foo',
+            'last_delta' => -8.50,
+            'last_run_id' => 42,
+        ]],
+    ]);
+});

--- a/tests/Feature/SkillEvalGateTest.php
+++ b/tests/Feature/SkillEvalGateTest.php
@@ -1,0 +1,218 @@
+<?php
+
+use App\Jobs\RunEvalSuiteJob;
+use App\Models\Project;
+use App\Models\Skill;
+use App\Models\SkillEvalGate;
+use App\Models\SkillEvalPrompt;
+use App\Models\SkillEvalRun;
+use App\Models\SkillEvalSuite;
+use App\Models\SkillVersion;
+use App\Services\SkillEvalGateService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->service = app(SkillEvalGateService::class);
+    $this->project = Project::create([
+        'name' => 'Gate Project',
+        'path' => '/tmp/gate-project',
+        'providers' => ['claude'],
+    ]);
+    $this->skill = Skill::create([
+        'project_id' => $this->project->id,
+        'name' => 'Gated Skill',
+        'slug' => 'gated-skill',
+        'body' => 'Skill body.',
+        'model' => 'claude-sonnet-4-6',
+        'tuned_for_model' => 'claude-sonnet-4-6',
+    ]);
+    $this->suite = SkillEvalSuite::create([
+        'skill_id' => $this->skill->id,
+        'name' => 'Main Suite',
+    ]);
+    SkillEvalPrompt::create([
+        'eval_suite_id' => $this->suite->id,
+        'prompt' => 'Summarize',
+        'expected_behavior' => 'Must mention bullets',
+        'sort_order' => 1,
+    ]);
+});
+
+it('findBaselineFor returns the most recent completed run for (suite, model)', function () {
+    $version1 = SkillVersion::create([
+        'skill_id' => $this->skill->id,
+        'version_number' => 1,
+        'frontmatter' => [],
+        'body' => 'v1',
+        'saved_at' => now()->subDays(2),
+    ]);
+    $version2 = SkillVersion::create([
+        'skill_id' => $this->skill->id,
+        'version_number' => 2,
+        'frontmatter' => [],
+        'body' => 'v2',
+        'saved_at' => now()->subDay(),
+    ]);
+
+    // Older run on v1
+    SkillEvalRun::create([
+        'eval_suite_id' => $this->suite->id,
+        'skill_version_id' => $version1->id,
+        'model' => 'claude-sonnet-4-6',
+        'mode' => 'with_skill',
+        'status' => 'completed',
+        'overall_score' => 80,
+        'completed_at' => now()->subDays(2),
+    ]);
+
+    // Newer run on v2 — should be baseline regardless of version
+    $newer = SkillEvalRun::create([
+        'eval_suite_id' => $this->suite->id,
+        'skill_version_id' => $version2->id,
+        'model' => 'claude-sonnet-4-6',
+        'mode' => 'with_skill',
+        'status' => 'completed',
+        'overall_score' => 90,
+        'completed_at' => now()->subDay(),
+    ]);
+
+    // Different model — should not be baseline
+    SkillEvalRun::create([
+        'eval_suite_id' => $this->suite->id,
+        'skill_version_id' => $version2->id,
+        'model' => 'claude-opus-4-6',
+        'mode' => 'with_skill',
+        'status' => 'completed',
+        'overall_score' => 95,
+        'completed_at' => now(),
+    ]);
+
+    $baseline = $this->service->findBaselineFor($this->skill, $this->suite, 'claude-sonnet-4-6');
+
+    expect($baseline)->not->toBeNull()
+        ->and($baseline->id)->toBe($newer->id);
+});
+
+it('computeDelta returns overall + per-prompt deltas', function () {
+    $current = new SkillEvalRun([
+        'overall_score' => 70,
+        'results' => [
+            ['prompt_id' => 1, 'score' => 60],
+            ['prompt_id' => 2, 'score' => 80],
+        ],
+    ]);
+    $baseline = new SkillEvalRun([
+        'overall_score' => 85,
+        'results' => [
+            ['prompt_id' => 1, 'score' => 90],
+            ['prompt_id' => 2, 'score' => 80],
+        ],
+    ]);
+
+    $delta = $this->service->computeDelta($current, $baseline);
+
+    expect($delta['overall_delta'])->toBe(-15.0)
+        ->and($delta['per_prompt'][0]['delta'])->toBe(-30)
+        ->and($delta['per_prompt'][1]['delta'])->toBe(0);
+});
+
+it('evaluateSkillSave enqueues runs for required suites when gate is on', function () {
+    Queue::fake();
+
+    SkillEvalGate::create([
+        'skill_id' => $this->skill->id,
+        'enabled' => true,
+        'required_suite_ids' => [$this->suite->id],
+        'fail_threshold_delta' => -5.00,
+        'auto_run_on_save' => true,
+        'block_sync' => false,
+    ]);
+    $this->skill->refresh();
+
+    $version = SkillVersion::create([
+        'skill_id' => $this->skill->id,
+        'version_number' => 1,
+        'frontmatter' => [],
+        'body' => 'v1',
+        'saved_at' => now(),
+    ]);
+
+    $decision = $this->service->evaluateSkillSave($this->skill, $version);
+
+    expect($decision['reason'])->toBe('dispatched')
+        ->and($decision['enqueued_run_ids'])->toHaveCount(1);
+
+    Queue::assertPushed(RunEvalSuiteJob::class);
+});
+
+it('evaluateSkillSave skips when gate disabled', function () {
+    Queue::fake();
+
+    $version = SkillVersion::create([
+        'skill_id' => $this->skill->id,
+        'version_number' => 1,
+        'frontmatter' => [],
+        'body' => 'v1',
+        'saved_at' => now(),
+    ]);
+
+    $decision = $this->service->evaluateSkillSave($this->skill, $version);
+
+    expect($decision['reason'])->toBe('no_gate')
+        ->and($decision['enqueued_run_ids'])->toBeEmpty();
+
+    Queue::assertNothingPushed();
+});
+
+it('canSync returns true when gate not enabled', function () {
+    expect($this->service->canSync($this->skill))->toBeTrue();
+});
+
+it('canSync returns false when latest run delta is below threshold', function () {
+    SkillEvalGate::create([
+        'skill_id' => $this->skill->id,
+        'enabled' => true,
+        'required_suite_ids' => [$this->suite->id],
+        'fail_threshold_delta' => -5.00,
+        'block_sync' => true,
+    ]);
+    $this->skill->refresh();
+
+    SkillEvalRun::create([
+        'eval_suite_id' => $this->suite->id,
+        'model' => 'claude-sonnet-4-6',
+        'mode' => 'with_skill',
+        'status' => 'completed',
+        'overall_score' => 70,
+        'delta_score' => -10.00,
+        'completed_at' => now(),
+    ]);
+
+    expect($this->service->canSync($this->skill))->toBeFalse();
+});
+
+it('canSync returns true when latest run delta is above threshold', function () {
+    SkillEvalGate::create([
+        'skill_id' => $this->skill->id,
+        'enabled' => true,
+        'required_suite_ids' => [$this->suite->id],
+        'fail_threshold_delta' => -5.00,
+        'block_sync' => true,
+    ]);
+    $this->skill->refresh();
+
+    SkillEvalRun::create([
+        'eval_suite_id' => $this->suite->id,
+        'model' => 'claude-sonnet-4-6',
+        'mode' => 'with_skill',
+        'status' => 'completed',
+        'overall_score' => 90,
+        'delta_score' => -2.00,
+        'completed_at' => now(),
+    ]);
+
+    expect($this->service->canSync($this->skill))->toBeTrue();
+});

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -349,6 +349,65 @@ export const fetchEvalRuns = (suiteId: number) =>
     .get<ApiResponse<SkillEvalRun[]>>(`/eval-suites/${suiteId}/runs`)
     .then((r) => r.data.data)
 
+export const fetchEvalRun = (runId: number) =>
+  api
+    .get<ApiResponse<SkillEvalRun>>(`/eval-runs/${runId}`)
+    .then((r) => r.data.data)
+
+// Skill Eval Gate
+export interface SkillEvalGateConfig {
+  id?: number
+  skill_id: number
+  enabled: boolean
+  required_suite_ids: number[] | null
+  fail_threshold_delta: string | number
+  auto_run_on_save: boolean
+  block_sync: boolean
+}
+
+export interface GateStatus {
+  enabled: boolean
+  pending_count: number
+  can_sync: boolean
+  runs: Array<{
+    suite_id: number
+    run_id: number
+    status: 'pending' | 'running' | 'completed' | 'failed'
+    overall_score: number | null
+    delta: {
+      overall_delta: number
+      per_prompt: Array<{
+        prompt_id: number | null
+        current: number
+        baseline: number | null
+        delta: number | null
+      }>
+    } | null
+  }>
+}
+
+export const fetchEvalGate = (skillId: number) =>
+  api
+    .get<{ data: SkillEvalGateConfig }>(`/skills/${skillId}/eval-gate`)
+    .then((r) => r.data.data)
+
+export const updateEvalGate = (skillId: number, data: Partial<SkillEvalGateConfig>) =>
+  api
+    .put<{ data: SkillEvalGateConfig }>(`/skills/${skillId}/eval-gate`, data)
+    .then((r) => r.data.data)
+
+export const runGateNow = (skillId: number) =>
+  api
+    .post<{ data: { enqueued_run_ids: number[]; baseline_info: Array<Record<string, unknown>>; est_duration_seconds: number; reason: string } }>(
+      `/skills/${skillId}/eval-gate/run-now`,
+    )
+    .then((r) => r.data.data)
+
+export const fetchGateStatus = (skillId: number) =>
+  api
+    .get<{ data: GateStatus }>(`/skills/${skillId}/eval-gate/status`)
+    .then((r) => r.data.data)
+
 export const scoreDescription = (skillId: number) =>
   api
     .get<ApiResponse<DescriptionScore>>(

--- a/ui/src/components/skills/EvalPanel.tsx
+++ b/ui/src/components/skills/EvalPanel.tsx
@@ -11,6 +11,8 @@ import {
   scoreDescription,
 } from '@/api/client'
 import { useConfirm } from '@/hooks/useConfirm'
+import { useEvalRunStatus } from '@/hooks/useEvalRunStatus'
+import { GateConfigPanel } from '@/components/skills/GateConfigPanel'
 import type {
   SkillEvalSuite,
   SkillEvalRun,
@@ -38,6 +40,16 @@ export function EvalPanel({ skillId }: EvalPanelProps) {
   const [runModel, setRunModel] = useState('claude-sonnet-4-6')
   const [runMode, setRunMode] = useState<string>('with_skill')
   const [running, setRunning] = useState(false)
+  const [activeRunId, setActiveRunId] = useState<number | null>(null)
+  const { run: pollingRun, isLive: pollingLive } = useEvalRunStatus(activeRunId)
+
+  useEffect(() => {
+    if (!pollingRun || pollingLive) return
+    if (selectedSuite) {
+      fetchEvalRuns(selectedSuite.id).then(setRuns)
+    }
+    setActiveRunId(null)
+  }, [pollingRun, pollingLive, selectedSuite])
 
   const load = useCallback(() => {
     fetchEvalSuites(skillId)
@@ -97,7 +109,8 @@ export function EvalPanel({ skillId }: EvalPanelProps) {
     if (!selectedSuite) return
     setRunning(true)
     try {
-      await runEval(selectedSuite.id, { model: runModel, mode: runMode })
+      const newRun = await runEval(selectedSuite.id, { model: runModel, mode: runMode })
+      setActiveRunId(newRun.id)
       fetchEvalRuns(selectedSuite.id).then(setRuns)
     } finally {
       setRunning(false)
@@ -119,6 +132,8 @@ export function EvalPanel({ skillId }: EvalPanelProps) {
 
   return (
     <div className="flex flex-col h-full">
+      <GateConfigPanel skillId={skillId} skillName="this skill" suites={suites} />
+
       {/* Description Score */}
       <div className="p-3 border-b border-border">
         <button

--- a/ui/src/components/skills/GateConfigPanel.tsx
+++ b/ui/src/components/skills/GateConfigPanel.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useState } from 'react'
+import {
+  fetchEvalGate,
+  updateEvalGate,
+  runGateNow,
+  type SkillEvalGateConfig,
+} from '@/api/client'
+import { useAppStore } from '@/store/useAppStore'
+import type { SkillEvalSuite } from '@/types'
+
+interface Props {
+  skillId: number
+  skillName: string
+  suites: SkillEvalSuite[]
+}
+
+export function GateConfigPanel({ skillId, skillName, suites }: Props) {
+  const [gate, setGate] = useState<SkillEvalGateConfig | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [runningNow, setRunningNow] = useState(false)
+  const registerPendingGate = useAppStore((s) => s.registerPendingGate)
+  const showToast = useAppStore((s) => s.showToast)
+
+  useEffect(() => {
+    fetchEvalGate(skillId)
+      .then(setGate)
+      .finally(() => setLoading(false))
+  }, [skillId])
+
+  const save = async (patch: Partial<SkillEvalGateConfig>) => {
+    setSaving(true)
+    try {
+      const next = await updateEvalGate(skillId, patch)
+      setGate(next)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const toggleSuite = (suiteId: number) => {
+    if (!gate) return
+    const current = new Set(gate.required_suite_ids ?? [])
+    if (current.has(suiteId)) current.delete(suiteId)
+    else current.add(suiteId)
+    save({ required_suite_ids: Array.from(current) })
+  }
+
+  const handleRunNow = async () => {
+    setRunningNow(true)
+    try {
+      const decision = await runGateNow(skillId)
+      if (decision.reason !== 'dispatched') {
+        showToast(`Cannot run: ${decision.reason}`, 'error')
+      } else {
+        registerPendingGate({
+          skillId,
+          skillName,
+          runIds: decision.enqueued_run_ids,
+          baselineInfo: decision.baseline_info as PendingBaselineInfo[],
+          estDurationSeconds: decision.est_duration_seconds,
+          startedAt: Date.now(),
+        })
+        showToast(`Queued ${decision.enqueued_run_ids.length} eval run(s)`)
+      }
+    } catch {
+      showToast('Failed to run eval gate', 'error')
+    } finally {
+      setRunningNow(false)
+    }
+  }
+
+  if (loading || !gate) {
+    return <div className="p-3 text-xs text-muted-foreground">Loading gate config…</div>
+  }
+
+  return (
+    <div className="p-3 space-y-3 border-b border-border text-xs">
+      <div className="flex items-center justify-between">
+        <span className="font-semibold uppercase tracking-wide text-muted-foreground">
+          Regression gate
+        </span>
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={gate.enabled}
+            disabled={saving}
+            onChange={(e) => save({ enabled: e.target.checked })}
+            className="rounded border-input"
+          />
+          <span>Enabled</span>
+        </label>
+      </div>
+
+      {gate.enabled && (
+        <>
+          <div>
+            <div className="font-medium mb-1">Required suites</div>
+            {suites.length === 0 ? (
+              <p className="text-muted-foreground">Create a suite above to use as a gate.</p>
+            ) : (
+              <div className="space-y-1">
+                {suites.map((s) => {
+                  const checked = (gate.required_suite_ids ?? []).includes(s.id)
+                  return (
+                    <label key={s.id} className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        disabled={saving}
+                        onChange={() => toggleSuite(s.id)}
+                        className="rounded border-input"
+                      />
+                      <span>{s.name}</span>
+                    </label>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+
+          <div className="flex items-center gap-2">
+            <label className="text-muted-foreground">Fail threshold Δ</label>
+            <input
+              type="number"
+              step="0.5"
+              value={Number(gate.fail_threshold_delta)}
+              disabled={saving}
+              onChange={(e) => save({ fail_threshold_delta: parseFloat(e.target.value) })}
+              className="w-20 px-2 py-1 text-xs border border-input bg-background rounded"
+            />
+          </div>
+
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={gate.auto_run_on_save}
+              disabled={saving}
+              onChange={(e) => save({ auto_run_on_save: e.target.checked })}
+              className="rounded border-input"
+            />
+            <span>Auto-run on save</span>
+          </label>
+
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={gate.block_sync}
+              disabled={saving}
+              onChange={(e) => save({ block_sync: e.target.checked })}
+              className="rounded border-input"
+            />
+            <span>Block sync on failure</span>
+          </label>
+
+          <button
+            onClick={handleRunNow}
+            disabled={runningNow || !(gate.required_suite_ids ?? []).length}
+            className="text-xs px-3 py-1.5 bg-primary text-primary-foreground rounded disabled:opacity-50"
+          >
+            {runningNow ? 'Queueing…' : 'Run gate now'}
+          </button>
+        </>
+      )}
+    </div>
+  )
+}
+
+type PendingBaselineInfo = {
+  suite_id: number
+  suite_name: string
+  run_id: number
+  baseline_run_id: number | null
+  baseline_score: number | null
+}

--- a/ui/src/components/skills/RegressionDeltaModal.tsx
+++ b/ui/src/components/skills/RegressionDeltaModal.tsx
@@ -1,0 +1,85 @@
+import { X } from 'lucide-react'
+import type { GateStatus } from '@/api/client'
+
+type RunEntry = GateStatus['runs'][number]
+
+interface Props {
+  runEntry: RunEntry
+  onClose: () => void
+}
+
+export function RegressionDeltaModal({ runEntry, onClose }: Props) {
+  const delta = runEntry.delta
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-foreground/30">
+      <div className="bg-background elevation-4 w-full max-w-2xl max-h-[85vh] flex flex-col border border-border rounded">
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <div>
+            <h3 className="text-sm font-semibold">Regression delta — run #{runEntry.run_id}</h3>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Overall score: {runEntry.overall_score ?? '—'}
+              {delta && (
+                <>
+                  {' · '}
+                  <span className={delta.overall_delta < 0 ? 'text-destructive' : 'text-foreground'}>
+                    Δ {delta.overall_delta > 0 ? '+' : ''}
+                    {delta.overall_delta.toFixed(1)}
+                  </span>
+                </>
+              )}
+            </p>
+          </div>
+          <button onClick={onClose} className="p-1 hover:bg-muted rounded">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4">
+          {!delta || delta.per_prompt.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No baseline available — this was the first completed run for this suite+model.
+            </p>
+          ) : (
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-border text-left text-muted-foreground">
+                  <th className="py-1.5 pr-2">Prompt</th>
+                  <th className="py-1.5 px-2 text-right">Baseline</th>
+                  <th className="py-1.5 px-2 text-right">Current</th>
+                  <th className="py-1.5 pl-2 text-right">Δ</th>
+                </tr>
+              </thead>
+              <tbody>
+                {delta.per_prompt.map((p, i) => {
+                  const d = p.delta
+                  const badge =
+                    d === null
+                      ? 'text-muted-foreground'
+                      : d < 0
+                        ? 'text-destructive'
+                        : d > 0
+                          ? 'text-green-600 dark:text-green-400'
+                          : 'text-muted-foreground'
+
+                  return (
+                    <tr key={i} className="border-b border-border">
+                      <td className="py-1.5 pr-2">#{p.prompt_id ?? i + 1}</td>
+                      <td className="py-1.5 px-2 text-right text-muted-foreground">
+                        {p.baseline ?? '—'}
+                      </td>
+                      <td className="py-1.5 px-2 text-right">{p.current}</td>
+                      <td className={`py-1.5 pl-2 text-right font-mono ${badge}`}>
+                        {d === null ? '—' : d > 0 ? `+${d}` : d}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/components/skills/RegressionGateBanner.tsx
+++ b/ui/src/components/skills/RegressionGateBanner.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react'
+import { fetchGateStatus, type GateStatus } from '@/api/client'
+import { useAppStore } from '@/store/useAppStore'
+import { RegressionDeltaModal } from '@/components/skills/RegressionDeltaModal'
+
+interface Props {
+  skillId: number
+  failThresholdDelta?: number
+}
+
+export function RegressionGateBanner({ skillId, failThresholdDelta = -5 }: Props) {
+  const pending = useAppStore((s) => s.pendingEvalGates[skillId])
+  const clearPendingGate = useAppStore((s) => s.clearPendingGate)
+  const [status, setStatus] = useState<GateStatus | null>(null)
+  const [deltaRunId, setDeltaRunId] = useState<number | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+
+    const tick = async () => {
+      try {
+        const s = await fetchGateStatus(skillId)
+        if (cancelled) return
+        setStatus(s)
+
+        if (s.pending_count > 0) {
+          timer = setTimeout(tick, 3000)
+        } else if (pending) {
+          clearPendingGate(skillId)
+        }
+      } catch {
+        if (!cancelled) timer = setTimeout(tick, 6000)
+      }
+    }
+
+    tick()
+
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [skillId, pending, clearPendingGate])
+
+  if (!status || !status.enabled) return null
+
+  const runsCount = status.runs.length
+  const completed = status.runs.filter((r) => r.status === 'completed')
+  const pendingCount = status.pending_count
+  const failed = completed.find(
+    (r) => r.delta && r.delta.overall_delta < failThresholdDelta,
+  )
+
+  let tone: 'info' | 'warn' | 'danger' = 'info'
+  let label = ''
+  let body = ''
+
+  if (pendingCount > 0) {
+    tone = 'info'
+    const total = pending?.runIds.length ?? runsCount
+    label = pendingCount === total ? 'Queued' : `Running (${total - pendingCount}/${total})`
+    body = 'Regression evals in progress…'
+  } else if (failed) {
+    tone = 'danger'
+    label = `Δ ${failed.delta!.overall_delta.toFixed(1)}`
+    body = 'Regression threshold breached — review the delta.'
+  } else if (completed.length > 0) {
+    const worst = completed.reduce((min, r) => {
+      const d = r.delta?.overall_delta ?? 0
+      return d < min ? d : min
+    }, 0)
+    if (worst < 0) {
+      tone = 'warn'
+      label = `Δ ${worst.toFixed(1)}`
+      body = 'Score dropped but within threshold.'
+    } else {
+      tone = 'info'
+      label = `Δ +${worst.toFixed(1)}`
+      body = 'Latest eval improved or held.'
+    }
+  } else {
+    return null
+  }
+
+  const style = {
+    info: { bg: 'bg-muted/40', border: 'border-border', text: 'text-muted-foreground' },
+    warn: { bg: 'bg-yellow-500/10', border: 'border-yellow-500/30', text: 'text-yellow-700 dark:text-yellow-400' },
+    danger: { bg: 'bg-red-500/10', border: 'border-red-500/30', text: 'text-red-700 dark:text-red-400' },
+  }[tone]
+
+  return (
+    <>
+      <div className={`flex items-center gap-3 px-3 h-8 border-b ${style.border} ${style.bg} text-xs`}>
+        <span className={`shrink-0 font-semibold ${style.text}`}>{label}</span>
+        <span className="flex-1 min-w-0 text-foreground/80 truncate">{body}</span>
+        {failed && (
+          <button
+            onClick={() => setDeltaRunId(failed.run_id)}
+            className="shrink-0 text-primary hover:underline font-medium"
+          >
+            see delta
+          </button>
+        )}
+      </div>
+
+      {deltaRunId !== null && status && (
+        <RegressionDeltaModal
+          runEntry={status.runs.find((r) => r.run_id === deltaRunId)!}
+          onClose={() => setDeltaRunId(null)}
+        />
+      )}
+    </>
+  )
+}

--- a/ui/src/hooks/useEvalRunStatus.ts
+++ b/ui/src/hooks/useEvalRunStatus.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react'
+import { fetchEvalRun } from '@/api/client'
+import type { SkillEvalRun } from '@/types'
+
+/**
+ * Poll an eval run until it leaves `pending`/`running`. Returns the latest
+ * run snapshot, whether it's still live, and a `version` integer that bumps
+ * on every update so callers can `useEffect` off of it.
+ */
+export function useEvalRunStatus(runId: number | null, intervalMs = 3000) {
+  const [run, setRun] = useState<SkillEvalRun | null>(null)
+  const [version, setVersion] = useState(0)
+
+  useEffect(() => {
+    if (!runId) {
+      setRun(null)
+      return
+    }
+
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+
+    const tick = async () => {
+      try {
+        const latest = await fetchEvalRun(runId)
+        if (cancelled) return
+        setRun(latest)
+        setVersion((v) => v + 1)
+
+        if (latest.status === 'pending' || latest.status === 'running') {
+          timer = setTimeout(tick, intervalMs)
+        }
+      } catch {
+        if (!cancelled) {
+          timer = setTimeout(tick, intervalMs * 2)
+        }
+      }
+    }
+
+    tick()
+
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [runId, intervalMs])
+
+  const isLive = run?.status === 'pending' || run?.status === 'running'
+
+  return { run, isLive, version }
+}

--- a/ui/src/pages/SkillEditor.tsx
+++ b/ui/src/pages/SkillEditor.tsx
@@ -25,6 +25,7 @@ import { AssetsPanel } from '@/components/skills/AssetsPanel'
 import { GotchaPanel } from '@/components/skills/GotchaPanel'
 import { InlineGotchaStrip } from '@/components/skills/InlineGotchaStrip'
 import { StalenessBanner } from '@/components/skills/StalenessBanner'
+import { RegressionGateBanner } from '@/components/skills/RegressionGateBanner'
 import { EvalPanel } from '@/components/skills/EvalPanel'
 import { GenerateSkillModal } from '@/components/skills/GenerateSkillModal'
 import { useConfirm } from '@/hooks/useConfirm'
@@ -244,6 +245,7 @@ export function SkillEditor() {
               refreshKey={stalenessRefreshKey}
             />
           )}
+          {!isNew && skill.id && <RegressionGateBanner skillId={skill.id} />}
           {!isNew && skill.id && (
             <InlineGotchaStrip
               skillId={skill.id}

--- a/ui/src/store/useAppStore.ts
+++ b/ui/src/store/useAppStore.ts
@@ -2,6 +2,21 @@ import { create } from 'zustand'
 import type { Project, Skill } from '@/types'
 import { fetchProjects } from '@/api/client'
 
+export interface PendingEvalGate {
+  skillId: number
+  skillName: string
+  runIds: number[]
+  baselineInfo: Array<{
+    suite_id: number
+    suite_name: string
+    run_id: number
+    baseline_run_id: number | null
+    baseline_score: number | null
+  }>
+  estDurationSeconds: number
+  startedAt: number
+}
+
 interface AppState {
   // Projects
   projects: Project[]
@@ -18,6 +33,11 @@ interface AppState {
   toast: { message: string; type: 'success' | 'error' } | null
   showToast: (message: string, type?: 'success' | 'error') => void
   clearToast: () => void
+
+  // Pending eval gates (survive navigation)
+  pendingEvalGates: Record<number, PendingEvalGate>
+  registerPendingGate: (gate: PendingEvalGate) => void
+  clearPendingGate: (skillId: number) => void
 }
 
 export const useAppStore = create<AppState>((set) => ({
@@ -25,6 +45,7 @@ export const useAppStore = create<AppState>((set) => ({
   activeProjectId: null,
   isDirty: false,
   toast: null,
+  pendingEvalGates: {},
 
   setProjects: (projects) => set({ projects }),
   setActiveProjectId: (id) => set({ activeProjectId: id }),
@@ -41,4 +62,16 @@ export const useAppStore = create<AppState>((set) => ({
   },
 
   clearToast: () => set({ toast: null }),
+
+  registerPendingGate: (gate) =>
+    set((state) => ({
+      pendingEvalGates: { ...state.pendingEvalGates, [gate.skillId]: gate },
+    })),
+
+  clearPendingGate: (skillId) =>
+    set((state) => {
+      const next = { ...state.pendingEvalGates }
+      delete next[skillId]
+      return { pendingEvalGates: next }
+    }),
 }))

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -116,10 +116,13 @@ export interface SkillEvalPrompt {
 export interface SkillEvalRun {
   id: number
   eval_suite_id: number
+  skill_version_id: number | null
+  baseline_run_id: number | null
   model: string
   mode: 'with_skill' | 'without_skill' | 'ab_test'
   status: 'pending' | 'running' | 'completed' | 'failed'
   overall_score: number | null
+  delta_score: number | null
   results: unknown[] | null
   started_at: string | null
   completed_at: string | null


### PR DESCRIPTION
## Summary

Phase 3 of the [Harness Engineering roadmap](https://github.com/eooo-io/orkestr/milestone/115). Skill saves now optionally trigger eval runs that grade the new version against a baseline, with per-skill configuration and the ability to block sync on regression.

## ⚠️ Operational note

Once this merges, **`QUEUE_CONNECTION` must not be `sync`**. `.env.example` calls this out explicitly. Eval runs are long-lived (30s–10min); running them synchronously would block HTTP requests and hit PHP's max_execution_time. Dev + staging + prod should all be `database` or `redis`.

## Architectural decisions worth calling out

- **Baseline = most recent completed run for (suite, model), regardless of which version it ran against.** Revalidating the same version twice doesn't zero out the delta — it updates the baseline. `SkillEvalGateTest::findBaselineFor` covers this explicitly.
- **`KeywordScorer` first, `LlmJudgeScorer` opt-in via `skill_eval_suites.scorer`.** Deterministic grading is what gates should run against; non-deterministic judge calls are available but off by default.
- **Pre-existing bug fixed along the way.** `EvalSuiteController::executeRun` was calling `provider->chat($messages, $opts)` but the interface has been `chat(system, messages, model, maxTokens)` the whole time. Live eval runs couldn't have worked; the placeholder `score = 70` was covering for it.

## Issue breakdown

### #534 — `ScorerInterface` + `KeywordScorer` + opt-in `LlmJudgeScorer`

- `app/Services/EvalScoring/ScorerInterface.php` + three implementations + `ScorerFactory`
- Migration adds `scorer` enum to `skill_eval_suites` (defaults to `keyword`)
- `KeywordScorer`: 0–100 based on non-stopword keyword hits; explains matched/missing in `signals`
- `LlmJudgeScorer`: second LLM call grading strict JSON, degrades gracefully on unparseable or error
- 9 Pest tests

### #535 — Queued `RunEvalSuiteJob` + polling

- `ShouldQueue` job with `timeout=900`, `failed()` stamps run as `failed`
- Controller dispatches; response is immediate pending run
- `GET /api/eval-runs/{id}` + new `useEvalRunStatus(runId)` polling hook (3s interval while live)
- `EvalPanel` uses the hook to refresh the run list on completion
- `.env.example` documents the sync-connection hazard
- 4 Pest tests

### #536 — Link `skill_eval_runs` to versions + baselines

- Columns: `skill_version_id`, `baseline_run_id`, `delta_score` + index on `(skill_version_id, status)`
- `SkillEvalRun` model relationships + TS type updated
- Dispatch path captures `skill_version_id` at dispatch time

### #537 — `skill_eval_gates` table + `SkillEvalGateService`

- One row per skill: `enabled`, `required_suite_ids json`, `fail_threshold_delta`, `auto_run_on_save`, `block_sync`
- `Skill::evalGate()` hasOne
- Service methods: `evaluateSkillSave`, `findBaselineFor`, `computeDelta`, `canSync`
- `SkillEvalGateController`: `GET|PUT /eval-gate`, `POST /eval-gate/run-now`, `GET /eval-gate/status`
- 7 Pest tests

### #538 — Wire gate into save + sync

- `SkillController::update` includes `gate_decision` on response via `SkillResource::additional()`
- `ProviderSyncService::syncProject` calls `assertCanSync($project)` first
- New `EvalGateBlockedException` renders as 409 with per-skill details
- 4 integration Pest tests

### #539 — `RegressionGateBanner` + `RegressionDeltaModal` + `pendingEvalGates` store slice

- Banner polls `/api/skills/{id}/eval-gate/status`; states: queued / running (n/m) / completed Δ / failed-threshold (red with "see delta")
- Modal renders per-prompt baseline vs current table with colored deltas
- `GateConfigPanel` at top of `EvalPanel` (enable, pick suites, threshold, toggles, run-now)
- Zustand slice `pendingEvalGates` keyed by `skillId` so the banner survives navigation
- Mounted under `StalenessBanner` + `InlineGotchaStrip` in `SkillEditor`

## Deferred from spec

**#538 org-level monthly eval budget cap.** The schema doesn't have `organizations.monthly_eval_budget_usd` and the cost pipeline isn't wired through the eval job yet. Easier to do in a follow-up once `CostCalculator` sees the eval path.

## Test plan

- [x] Backend: 335/335 skill/eval/agent/compose/lint/sync tests pass
- [x] UI: `tsc --noEmit` clean
- [x] Pest: 24 new tests across `EvalScoringTest`, `EvalJobTest`, `SkillEvalGateTest`, `SkillEvalGateIntegrationTest`
- [ ] Manual: enable gate on a skill → save → `gate_decision.reason === dispatched` in response → banner shows "Queued"
- [ ] Manual: worker processes run → banner flips to "running (n/m)" → then "Δ +X" or "Δ -X"
- [ ] Manual: force a regression (edit body to produce bad responses) → red banner + delta modal shows per-prompt drops
- [ ] Manual: with `block_sync=true` and a failing run, hit `/sync` → 409 with `blocked_skills[]`
- [ ] Manual: create a suite with `scorer: llm_judge`, run it with a configured API key → integer score returned

Closes #534
Closes #535
Closes #536
Closes #537
Closes #538
Closes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)