### PR TITLE
Phase 5: agent social layer (#542–#545)

### DIFF
--- a/app/Http/Controllers/AgentController.php
+++ b/app/Http/Controllers/AgentController.php
@@ -512,4 +512,57 @@ class AgentController extends Controller
             'data' => $this->composeService->composeAll($project, $depth),
         ]);
     }
+
+    /**
+     * Public-facing agent profile: owner, specialization, reputation, recent runs.
+     * Used by the directory + routing views.
+     */
+    public function profile(Agent $agent): JsonResponse
+    {
+        $agent->load(['owner']);
+
+        $skillNames = \Illuminate\Support\Facades\DB::table('agent_skill')
+            ->join('skills', 'skills.id', '=', 'agent_skill.skill_id')
+            ->where('agent_skill.agent_id', $agent->id)
+            ->pluck('skills.name', 'skills.slug');
+
+        $runCount = \App\Models\ExecutionRun::where('agent_id', $agent->id)->count();
+        $recentRunsQuery = \App\Models\ExecutionRun::where('agent_id', $agent->id)
+            ->orderByDesc('created_at')
+            ->limit(10)
+            ->select(['id', 'uuid', 'status', 'created_at', 'total_tokens', 'total_duration_ms']);
+
+        if (\Illuminate\Support\Facades\Schema::hasColumn('execution_runs', 'visibility')) {
+            $recentRunsQuery->where('visibility', '!=', 'private');
+        }
+
+        $recentRuns = $recentRunsQuery->get();
+
+        $domainSummary = $skillNames->isEmpty()
+            ? 'No attached skills'
+            : 'Specializes in: ' . $skillNames->values()->take(5)->implode(', ');
+
+        return response()->json([
+            'data' => [
+                'id' => $agent->id,
+                'uuid' => $agent->uuid,
+                'name' => $agent->name,
+                'slug' => $agent->slug,
+                'icon' => $agent->icon,
+                'role' => $agent->role,
+                'description' => $agent->description,
+                'owner' => $agent->owner ? [
+                    'id' => $agent->owner->id,
+                    'name' => $agent->owner->name,
+                    'email' => $agent->owner->email,
+                ] : null,
+                'reputation_score' => $agent->reputation_score,
+                'reputation_last_computed_at' => $agent->reputation_last_computed_at?->toIso8601String(),
+                'domain_summary' => $domainSummary,
+                'skill_slugs' => $skillNames->keys()->values(),
+                'total_invocations' => $runCount,
+                'recent_runs' => $recentRuns,
+            ],
+        ]);
+    }
 }

--- a/app/Http/Controllers/AgentRouteController.php
+++ b/app/Http/Controllers/AgentRouteController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\AgentRoutingService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class AgentRouteController extends Controller
+{
+    public function __construct(
+        protected AgentRoutingService $routing,
+    ) {}
+
+    public function route(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'question' => 'required|string|min:3|max:500',
+            'project_id' => 'nullable|integer|exists:projects,id',
+        ]);
+
+        $rankings = $this->routing->rank(
+            $validated['question'],
+            $validated['project_id'] ?? null,
+        );
+
+        return response()->json(['data' => $rankings]);
+    }
+}

--- a/app/Http/Controllers/ProjectRoleAssignmentController.php
+++ b/app/Http/Controllers/ProjectRoleAssignmentController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Project;
+use App\Models\ProjectRoleAssignment;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ProjectRoleAssignmentController extends Controller
+{
+    public function index(Project $project): JsonResponse
+    {
+        $assignments = ProjectRoleAssignment::where('project_id', $project->id)
+            ->active()
+            ->with('user:id,name,email')
+            ->orderBy('role')
+            ->get();
+
+        return response()->json(['data' => $assignments]);
+    }
+
+    public function store(Request $request, Project $project): JsonResponse
+    {
+        $validated = $request->validate([
+            'user_id' => 'required|integer|exists:users,id',
+            'role' => 'required|string|in:ic,dri,coach',
+            'scope' => 'nullable|string|max:200',
+            'started_at' => 'nullable|date',
+        ]);
+
+        $assignment = ProjectRoleAssignment::create([
+            'project_id' => $project->id,
+            'user_id' => $validated['user_id'],
+            'role' => $validated['role'],
+            'scope' => $validated['scope'] ?? null,
+            'started_at' => $validated['started_at'] ?? now(),
+        ]);
+
+        return response()->json([
+            'data' => $assignment->load('user:id,name,email'),
+        ], 201);
+    }
+
+    public function update(Request $request, Project $project, ProjectRoleAssignment $assignment): JsonResponse
+    {
+        if ($assignment->project_id !== $project->id) {
+            abort(404);
+        }
+
+        $validated = $request->validate([
+            'role' => 'sometimes|string|in:ic,dri,coach',
+            'scope' => 'nullable|string|max:200',
+            'ended_at' => 'nullable|date',
+        ]);
+
+        $assignment->update($validated);
+
+        return response()->json(['data' => $assignment->fresh('user:id,name,email')]);
+    }
+
+    public function destroy(Project $project, ProjectRoleAssignment $assignment): JsonResponse
+    {
+        if ($assignment->project_id !== $project->id) {
+            abort(404);
+        }
+
+        $assignment->update(['ended_at' => now()]);
+
+        return response()->json(['message' => 'Assignment ended']);
+    }
+}

--- a/app/Http/Controllers/WorkFeedController.php
+++ b/app/Http/Controllers/WorkFeedController.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ExecutionRun;
+use App\Models\Project;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class WorkFeedController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'agent_id' => 'nullable|integer|exists:agents,id',
+            'user_id' => 'nullable|integer|exists:users,id',
+            'project_id' => 'nullable|integer|exists:projects,id',
+            'per_page' => 'nullable|integer|min:1|max:50',
+        ]);
+
+        $user = Auth::user();
+        $orgId = $user?->current_organization_id;
+
+        $query = ExecutionRun::query()
+            ->with(['agent.owner', 'creator'])
+            ->whereIn('visibility', ['team', 'org'])
+            ->whereIn('status', ['completed', 'halted_guardrail']) // don't surface running/pending
+            ->orderByDesc('created_at');
+
+        if ($orgId) {
+            $query->whereIn('project_id',
+                Project::where('organization_id', $orgId)->pluck('id'),
+            );
+        }
+
+        if ($agentId = $validated['agent_id'] ?? null) {
+            $query->where('agent_id', $agentId);
+        }
+        if ($userId = $validated['user_id'] ?? null) {
+            $query->where('created_by', $userId);
+        }
+        if ($projectId = $validated['project_id'] ?? null) {
+            $query->where('project_id', $projectId);
+        }
+
+        $page = $query->paginate($validated['per_page'] ?? 25);
+
+        $items = collect($page->items())->map(fn (ExecutionRun $run) => [
+            'id' => $run->id,
+            'uuid' => $run->uuid,
+            'status' => $run->status,
+            'visibility' => $run->visibility,
+            'created_at' => $run->created_at->toIso8601String(),
+            'agent' => $run->agent ? [
+                'id' => $run->agent->id,
+                'name' => $run->agent->name,
+                'slug' => $run->agent->slug,
+                'icon' => $run->agent->icon,
+                'owner' => $run->agent->owner ? [
+                    'id' => $run->agent->owner->id,
+                    'name' => $run->agent->owner->name,
+                ] : null,
+            ] : null,
+            'creator' => $run->creator ? [
+                'id' => $run->creator->id,
+                'name' => $run->creator->name,
+            ] : null,
+            'input_summary' => $this->summarize($run->input),
+            'total_tokens' => $run->total_tokens,
+            'halt_reason' => $run->halt_reason,
+        ])->values();
+
+        return response()->json([
+            'data' => $items,
+            'meta' => [
+                'current_page' => $page->currentPage(),
+                'last_page' => $page->lastPage(),
+                'total' => $page->total(),
+            ],
+        ]);
+    }
+
+    public function fork(ExecutionRun $run): JsonResponse
+    {
+        if ($run->visibility === 'private' && $run->created_by !== Auth::id()) {
+            abort(403, 'This run is private.');
+        }
+
+        $draft = ExecutionRun::create([
+            'project_id' => $run->project_id,
+            'agent_id' => $run->agent_id,
+            'input' => $run->input,
+            'config' => $run->config,
+            'status' => 'pending',
+            'visibility' => 'private',
+            'created_by' => Auth::id(),
+            'forked_from_run_id' => $run->id,
+        ]);
+
+        return response()->json([
+            'data' => [
+                'id' => $draft->id,
+                'uuid' => $draft->uuid,
+                'forked_from_run_id' => $run->id,
+            ],
+        ], 201);
+    }
+
+    public function setVisibility(Request $request, ExecutionRun $run): JsonResponse
+    {
+        if ($run->created_by !== Auth::id()) {
+            abort(403, 'Only the creator can change visibility.');
+        }
+
+        $validated = $request->validate([
+            'visibility' => 'required|string|in:private,team,org',
+        ]);
+
+        $run->update(['visibility' => $validated['visibility']]);
+
+        return response()->json([
+            'data' => ['visibility' => $run->visibility],
+        ]);
+    }
+
+    protected function summarize(?array $input): string
+    {
+        if (! $input) return '';
+        $text = (string) ($input['message'] ?? $input['goal'] ?? '');
+
+        return mb_strimwidth($text, 0, 200, '…');
+    }
+}

--- a/app/Jobs/RecomputeAgentReputationJob.php
+++ b/app/Jobs/RecomputeAgentReputationJob.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Agent;
+use App\Services\AgentReputationService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Nightly recompute of reputation scores across all agents.
+ * Dispatched by the scheduler; safe to run ad-hoc.
+ */
+class RecomputeAgentReputationJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public ?int $agentId = null) {}
+
+    public function handle(AgentReputationService $service): void
+    {
+        $query = Agent::query();
+        if ($this->agentId !== null) {
+            $query->where('id', $this->agentId);
+        }
+
+        $query->chunkById(50, function ($agents) use ($service) {
+            foreach ($agents as $agent) {
+                $service->computeFor($agent);
+            }
+        });
+    }
+}

--- a/app/Models/Agent.php
+++ b/app/Models/Agent.php
@@ -79,6 +79,9 @@ class Agent extends Model
         // Meta
         'is_template',
         'created_by',
+        'owner_user_id',
+        'reputation_score',
+        'reputation_last_computed_at',
     ];
 
     protected function casts(): array
@@ -111,6 +114,8 @@ class Agent extends Model
             'daily_budget_limit_usd' => 'decimal:4',
             'run_token_budget' => 'integer',
             'run_cost_budget_usd' => 'decimal:4',
+            'reputation_score' => 'decimal:2',
+            'reputation_last_computed_at' => 'datetime',
             'allowed_tools' => 'array',
             'blocked_tools' => 'array',
             'data_access_scope' => 'array',
@@ -170,6 +175,11 @@ class Agent extends Model
     public function creator(): BelongsTo
     {
         return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function owner(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'owner_user_id');
     }
 
     public function mcpServers(): BelongsToMany

--- a/app/Models/ExecutionRun.php
+++ b/app/Models/ExecutionRun.php
@@ -35,6 +35,8 @@ class ExecutionRun extends Model
         'halt_step_id',
         'token_budget',
         'cost_budget_microcents',
+        'visibility',
+        'forked_from_run_id',
     ];
 
     protected $attributes = [

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -27,6 +27,7 @@ class Organization extends Model
         'max_agent_turns_per_run',
         'default_run_token_budget',
         'default_run_cost_budget_usd',
+        'default_run_visibility',
     ];
 
     protected function casts(): array

--- a/app/Models/ProjectRoleAssignment.php
+++ b/app/Models/ProjectRoleAssignment.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ProjectRoleAssignment extends Model
+{
+    public const ROLE_IC = 'ic';
+    public const ROLE_DRI = 'dri';
+    public const ROLE_COACH = 'coach';
+
+    public const ROLES = [self::ROLE_IC, self::ROLE_DRI, self::ROLE_COACH];
+
+    protected $fillable = [
+        'project_id',
+        'user_id',
+        'role',
+        'scope',
+        'started_at',
+        'ended_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'started_at' => 'datetime',
+            'ended_at' => 'datetime',
+        ];
+    }
+
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function isActive(): bool
+    {
+        return $this->ended_at === null || $this->ended_at->isFuture();
+    }
+
+    public function scopeActive($query)
+    {
+        return $query->where(function ($q) {
+            $q->whereNull('ended_at')->orWhere('ended_at', '>', now());
+        });
+    }
+}

--- a/app/Services/AgentReputationService.php
+++ b/app/Services/AgentReputationService.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Agent;
+use App\Models\ExecutionRun;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Compute an agent's reputation score from its run history.
+ *
+ * The formula is intentionally simple and auditable: stakeholders can read
+ * the code and understand exactly why an agent is at 72.5 vs 68.0.
+ */
+class AgentReputationService
+{
+    public const WINDOW_DAYS = 30;
+    public const MIN_RUNS_FOR_SCORE = 3;
+
+    /**
+     * Recompute and persist the reputation for a single agent.
+     */
+    public function computeFor(Agent $agent): float
+    {
+        $score = $this->calculate($agent);
+
+        $agent->update([
+            'reputation_score' => $score,
+            'reputation_last_computed_at' => now(),
+        ]);
+
+        return $score;
+    }
+
+    /**
+     * Pure function — doesn't persist. Useful for tests + preview.
+     *
+     * Formula:
+     *   - start at 50 (neutral)
+     *   - + up to 30 pts for success rate on last 30 days of runs
+     *   - + up to 15 pts for positive review ratio (if reviews exist)
+     *   - − up to 20 pts for guardrail halt rate
+     *   - clamp to [0, 100]
+     *   - return 0 when no signal (< MIN_RUNS_FOR_SCORE runs)
+     */
+    public function calculate(Agent $agent): float
+    {
+        $since = now()->subDays(self::WINDOW_DAYS);
+        $runs = ExecutionRun::where('agent_id', $agent->id)
+            ->where('created_at', '>=', $since)
+            ->select('status')
+            ->get();
+
+        if ($runs->count() < self::MIN_RUNS_FOR_SCORE) {
+            return 0.0;
+        }
+
+        $total = $runs->count();
+        $completed = $runs->where('status', 'completed')->count();
+        $halted = $runs->where('status', 'halted_guardrail')->count();
+        $failed = $runs->where('status', 'failed')->count();
+
+        $successRate = $completed / max(1, $total);
+        $haltRate = $halted / max(1, $total);
+
+        $score = 50.0;
+        $score += $successRate * 30.0;      // up to +30
+        $score -= $haltRate * 20.0;         // up to -20
+        $score -= ($failed / max(1, $total)) * 10.0; // up to -10 for plain failures
+
+        $reviewSignal = $this->reviewSignal($agent);
+        if ($reviewSignal !== null) {
+            $score += $reviewSignal * 15.0; // up to +/-15
+        }
+
+        return (float) round(max(0.0, min(100.0, $score)), 2);
+    }
+
+    /**
+     * Returns a value in [-1, 1] based on review ratio, or null when no reviews.
+     * Agents without reviews don't get penalized.
+     */
+    protected function reviewSignal(Agent $agent): ?float
+    {
+        // Reviews are tied to skills, not agents directly. Use the agent's attached
+        // skills to infer a review signal.
+        $skillIds = DB::table('agent_skill')
+            ->where('agent_id', $agent->id)
+            ->pluck('skill_id');
+
+        if ($skillIds->isEmpty()) {
+            return null;
+        }
+
+        if (! DB::getSchemaBuilder()->hasTable('skill_reviews')) {
+            return null;
+        }
+
+        $reviews = DB::table('skill_reviews')
+            ->whereIn('skill_id', $skillIds)
+            ->select('status')
+            ->get();
+
+        if ($reviews->count() === 0) {
+            return null;
+        }
+
+        $approved = $reviews->where('status', 'approved')->count();
+        $rejected = $reviews->where('status', 'rejected')->count();
+        $net = $approved - $rejected;
+
+        return max(-1.0, min(1.0, $net / max(1, $reviews->count())));
+    }
+}

--- a/app/Services/AgentRoutingService.php
+++ b/app/Services/AgentRoutingService.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Agent;
+use App\Models\ExecutionRun;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * "Who should I ask about X?" — ranks agents by how well their attached skills
+ * and recent execution inputs match a natural-language question. Intentionally
+ * simple: term-frequency overlap, no vector search yet.
+ */
+class AgentRoutingService
+{
+    public const MAX_RESULTS = 10;
+    public const RUN_SAMPLE_SIZE = 30;
+
+    /**
+     * @return array<int, array{agent_id: int, name: string, score: float, reasoning: string, reputation_score: float|null, owner: array|null}>
+     */
+    public function rank(string $question, ?int $projectId = null): array
+    {
+        $questionTokens = $this->tokenize($question);
+        if (empty($questionTokens)) {
+            return [];
+        }
+
+        $agentsQuery = Agent::query()->with('owner');
+        if ($projectId !== null) {
+            $agentIds = DB::table('project_agent')
+                ->where('project_id', $projectId)
+                ->where('is_enabled', true)
+                ->pluck('agent_id');
+            $agentsQuery->whereIn('id', $agentIds);
+        }
+
+        $agents = $agentsQuery->get();
+        $rankings = [];
+
+        foreach ($agents as $agent) {
+            $skillOverlap = $this->scoreSkillOverlap($agent->id, $questionTokens);
+            $runOverlap = $this->scoreRunOverlap($agent->id, $questionTokens);
+
+            $score = ($skillOverlap * 0.7) + ($runOverlap * 0.3);
+            if ($score <= 0) continue;
+
+            $reasoning = $this->buildReasoning($skillOverlap, $runOverlap);
+
+            $rankings[] = [
+                'agent_id' => $agent->id,
+                'slug' => $agent->slug,
+                'name' => $agent->name,
+                'icon' => $agent->icon,
+                'role' => $agent->role,
+                'score' => round($score, 3),
+                'reasoning' => $reasoning,
+                'reputation_score' => $agent->reputation_score !== null
+                    ? (float) $agent->reputation_score
+                    : null,
+                'owner' => $agent->owner ? [
+                    'id' => $agent->owner->id,
+                    'name' => $agent->owner->name,
+                ] : null,
+            ];
+        }
+
+        usort($rankings, fn ($a, $b) => $b['score'] <=> $a['score']);
+
+        return array_slice($rankings, 0, self::MAX_RESULTS);
+    }
+
+    /**
+     * Fraction of question tokens that appear in any attached skill's name/description/summary.
+     */
+    protected function scoreSkillOverlap(int $agentId, array $tokens): float
+    {
+        $rows = DB::table('agent_skill')
+            ->join('skills', 'skills.id', '=', 'agent_skill.skill_id')
+            ->where('agent_skill.agent_id', $agentId)
+            ->select('skills.name', 'skills.description', 'skills.summary')
+            ->get();
+
+        if ($rows->isEmpty()) return 0.0;
+
+        $combined = mb_strtolower($rows->map(fn ($r) => trim(
+            ($r->name ?? '') . ' ' . ($r->description ?? '') . ' ' . ($r->summary ?? '')
+        ))->implode(' '));
+
+        $hits = 0;
+        foreach ($tokens as $t) {
+            if (str_contains($combined, $t)) $hits++;
+        }
+
+        return $hits / count($tokens);
+    }
+
+    /**
+     * Fraction of question tokens that appear in recent run inputs.
+     */
+    protected function scoreRunOverlap(int $agentId, array $tokens): float
+    {
+        $inputs = ExecutionRun::where('agent_id', $agentId)
+            ->orderByDesc('created_at')
+            ->limit(self::RUN_SAMPLE_SIZE)
+            ->pluck('input');
+
+        if ($inputs->isEmpty()) return 0.0;
+
+        $combined = '';
+        foreach ($inputs as $raw) {
+            $input = is_string($raw) ? json_decode($raw, true) : $raw;
+            if (! is_array($input)) continue;
+            $text = ($input['message'] ?? '') . ' ' . ($input['goal'] ?? '');
+            $combined .= ' ' . mb_strtolower($text);
+        }
+
+        if (trim($combined) === '') return 0.0;
+
+        $hits = 0;
+        foreach ($tokens as $t) {
+            if (str_contains($combined, $t)) $hits++;
+        }
+
+        return $hits / count($tokens);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function tokenize(string $text): array
+    {
+        $stopwords = [
+            'the', 'a', 'an', 'and', 'or', 'but', 'of', 'to', 'in', 'on',
+            'at', 'for', 'with', 'by', 'from', 'is', 'are', 'was', 'were',
+            'who', 'what', 'when', 'where', 'why', 'how', 'should', 'ask',
+            'about', 'do', 'does', 'did', 'can', 'could', 'would',
+        ];
+
+        $tokens = preg_split('/[^\p{L}\p{N}]+/u', mb_strtolower($text), -1, PREG_SPLIT_NO_EMPTY) ?: [];
+
+        return array_values(array_unique(array_filter(
+            $tokens,
+            fn (string $t) => mb_strlen($t) >= 3 && ! in_array($t, $stopwords, true),
+        )));
+    }
+
+    protected function buildReasoning(float $skillOverlap, float $runOverlap): string
+    {
+        $parts = [];
+        if ($skillOverlap > 0) {
+            $parts[] = sprintf('%d%% skill overlap', (int) round($skillOverlap * 100));
+        }
+        if ($runOverlap > 0) {
+            $parts[] = sprintf('%d%% past-run overlap', (int) round($runOverlap * 100));
+        }
+
+        return $parts ? implode(', ', $parts) : 'no strong signal';
+    }
+}

--- a/database/migrations/2026_04_19_071356_add_ownership_and_reputation_to_agents.php
+++ b/database/migrations/2026_04_19_071356_add_ownership_and_reputation_to_agents.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('agents', function (Blueprint $table) {
+            $table->foreignId('owner_user_id')
+                ->nullable()
+                ->after('created_by')
+                ->constrained('users')
+                ->nullOnDelete();
+
+            $table->decimal('reputation_score', 5, 2)->nullable()->after('owner_user_id');
+            $table->timestamp('reputation_last_computed_at')->nullable()->after('reputation_score');
+        });
+
+        // Backfill: creator becomes initial owner
+        DB::table('agents')
+            ->whereNull('owner_user_id')
+            ->whereNotNull('created_by')
+            ->update(['owner_user_id' => DB::raw('created_by')]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('agents', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('owner_user_id');
+            $table->dropColumn(['reputation_score', 'reputation_last_computed_at']);
+        });
+    }
+};

--- a/database/migrations/2026_04_19_071732_add_visibility_to_execution_runs.php
+++ b/database/migrations/2026_04_19_071732_add_visibility_to_execution_runs.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('execution_runs', function (Blueprint $table) {
+            // varchar (not native enum) so swapping values later doesn't require a migration
+            $table->string('visibility', 16)->default('private')->after('status');
+            $table->foreignId('forked_from_run_id')
+                ->nullable()
+                ->after('visibility')
+                ->constrained('execution_runs')
+                ->nullOnDelete();
+
+            $table->index(['visibility', 'created_at']);
+        });
+
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->string('default_run_visibility', 16)->default('private')->after('default_run_cost_budget_usd');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->dropColumn('default_run_visibility');
+        });
+
+        Schema::table('execution_runs', function (Blueprint $table) {
+            $table->dropIndex(['visibility', 'created_at']);
+            $table->dropConstrainedForeignId('forked_from_run_id');
+            $table->dropColumn('visibility');
+        });
+    }
+};

--- a/database/migrations/2026_04_19_071837_create_project_role_assignments_table.php
+++ b/database/migrations/2026_04_19_071837_create_project_role_assignments_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('project_role_assignments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('project_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('role', 16); // 'ic', 'dri', 'coach'
+            $table->string('scope', 200)->nullable();
+            $table->timestamp('started_at')->nullable();
+            $table->timestamp('ended_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['project_id', 'role']);
+            $table->index(['user_id', 'role']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('project_role_assignments');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Http\Controllers\AgentController;
+use App\Http\Controllers\AgentRouteController;
 use App\Http\Controllers\ComposeShareController;
+use App\Http\Controllers\WorkFeedController;
 use App\Http\Controllers\ArtifactController;
 use App\Http\Controllers\BundleController;
 use App\Http\Controllers\LibraryController;
@@ -253,6 +255,19 @@ Route::middleware('auth:web')->group(function () {
     Route::get('/agents/overview', [PerformanceDashboardController::class, 'agentsOverview']);
     Route::post('/agents', [AgentController::class, 'store'])->middleware('org-role:editor');
     Route::get('/agents/{agent}', [AgentController::class, 'show']);
+    Route::get('/agents/{agent}/profile', [AgentController::class, 'profile']);
+    Route::post('/agents/route', [AgentRouteController::class, 'route']);
+
+    // Work feed + run visibility + fork
+    Route::get('/work-feed', [WorkFeedController::class, 'index']);
+    Route::post('/runs/{run}/fork', [WorkFeedController::class, 'fork']);
+    Route::put('/runs/{run}/visibility', [WorkFeedController::class, 'setVisibility']);
+
+    // Project role assignments (IC / DRI / coach)
+    Route::get('/projects/{project}/role-assignments', [\App\Http\Controllers\ProjectRoleAssignmentController::class, 'index']);
+    Route::post('/projects/{project}/role-assignments', [\App\Http\Controllers\ProjectRoleAssignmentController::class, 'store'])->middleware('org-role:editor');
+    Route::put('/projects/{project}/role-assignments/{assignment}', [\App\Http\Controllers\ProjectRoleAssignmentController::class, 'update'])->middleware('org-role:editor');
+    Route::delete('/projects/{project}/role-assignments/{assignment}', [\App\Http\Controllers\ProjectRoleAssignmentController::class, 'destroy'])->middleware('org-role:editor');
     Route::put('/agents/{agent}', [AgentController::class, 'update'])->middleware('org-role:editor');
     Route::delete('/agents/{agent}', [AgentController::class, 'destroy'])->middleware('org-role:editor');
     Route::post('/agents/{agent}/duplicate', [AgentController::class, 'duplicate']);

--- a/routes/console.php
+++ b/routes/console.php
@@ -10,3 +10,4 @@ Artisan::command('inspire', function () {
 
 Schedule::command('schedules:process')->everyMinute()->withoutOverlapping();
 Schedule::command('orkestr:run-schedules')->everyMinute()->withoutOverlapping();
+Schedule::job(new \App\Jobs\RecomputeAgentReputationJob())->dailyAt('03:00');

--- a/tests/Feature/AgentReputationTest.php
+++ b/tests/Feature/AgentReputationTest.php
@@ -1,0 +1,144 @@
+<?php
+
+use App\Jobs\RecomputeAgentReputationJob;
+use App\Models\Agent;
+use App\Models\ExecutionRun;
+use App\Models\Project;
+use App\Models\User;
+use App\Services\AgentReputationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->service = app(AgentReputationService::class);
+
+    $this->user = User::firstOrCreate(
+        ['email' => 'rep@test.com'],
+        ['name' => 'Rep Tester', 'password' => bcrypt('password')],
+    );
+
+    $this->project = Project::create([
+        'name' => 'Rep Project',
+        'path' => '/tmp/rep',
+        'providers' => ['claude'],
+        'owner_id' => $this->user->id,
+    ]);
+
+    $this->agent = Agent::create([
+        'name' => 'Repper',
+        'role' => 'worker',
+        'base_instructions' => 'hi',
+        'model' => 'claude-sonnet-4-6',
+        'objective_template' => 'x',
+        'success_criteria' => [],
+        'max_iterations' => 5,
+        'planning_mode' => 'plan_then_act',
+        'loop_condition' => 'goal_met',
+        'owner_user_id' => $this->user->id,
+        'created_by' => $this->user->id,
+    ]);
+});
+
+function seedRun(int $agentId, int $projectId, string $status): ExecutionRun
+{
+    return ExecutionRun::create([
+        'project_id' => $projectId,
+        'agent_id' => $agentId,
+        'input' => [],
+        'status' => $status,
+    ]);
+}
+
+it('returns 0 when agent has fewer than MIN_RUNS_FOR_SCORE runs', function () {
+    seedRun($this->agent->id, $this->project->id, 'completed');
+    seedRun($this->agent->id, $this->project->id, 'completed');
+
+    expect($this->service->calculate($this->agent))->toBe(0.0);
+});
+
+it('boosts score for a high success rate', function () {
+    for ($i = 0; $i < 10; $i++) {
+        seedRun($this->agent->id, $this->project->id, 'completed');
+    }
+
+    $score = $this->service->calculate($this->agent);
+
+    expect($score)->toBeGreaterThan(75.0);
+});
+
+it('penalizes halted_guardrail rate', function () {
+    for ($i = 0; $i < 8; $i++) {
+        seedRun($this->agent->id, $this->project->id, 'completed');
+    }
+    for ($i = 0; $i < 2; $i++) {
+        seedRun($this->agent->id, $this->project->id, 'halted_guardrail');
+    }
+
+    $allGood = 50.0 + 30.0; // baseline for all-completed
+    $withHalts = $this->service->calculate($this->agent);
+
+    expect($withHalts)->toBeLessThan($allGood);
+});
+
+it('penalizes plain failures differently than halts', function () {
+    for ($i = 0; $i < 7; $i++) {
+        seedRun($this->agent->id, $this->project->id, 'completed');
+    }
+    for ($i = 0; $i < 3; $i++) {
+        seedRun($this->agent->id, $this->project->id, 'failed');
+    }
+
+    $score = $this->service->calculate($this->agent);
+
+    expect($score)->toBeLessThan(80.0)
+        ->and($score)->toBeGreaterThan(40.0);
+});
+
+it('persists the score and timestamp via computeFor', function () {
+    for ($i = 0; $i < 5; $i++) {
+        seedRun($this->agent->id, $this->project->id, 'completed');
+    }
+
+    $this->service->computeFor($this->agent);
+    $fresh = $this->agent->fresh();
+
+    expect((float) $fresh->reputation_score)->toBeGreaterThan(0.0)
+        ->and($fresh->reputation_last_computed_at)->not->toBeNull();
+});
+
+it('RecomputeAgentReputationJob iterates all agents', function () {
+    $otherAgent = Agent::create([
+        'name' => 'Other',
+        'role' => 'worker',
+        'base_instructions' => 'hi',
+        'model' => 'claude-sonnet-4-6',
+        'objective_template' => 'x',
+        'success_criteria' => [],
+        'max_iterations' => 5,
+        'planning_mode' => 'plan_then_act',
+        'loop_condition' => 'goal_met',
+        'owner_user_id' => $this->user->id,
+    ]);
+
+    for ($i = 0; $i < 5; $i++) {
+        seedRun($this->agent->id, $this->project->id, 'completed');
+    }
+
+    (new RecomputeAgentReputationJob())->handle($this->service);
+
+    expect($this->agent->fresh()->reputation_last_computed_at)->not->toBeNull()
+        ->and($otherAgent->fresh()->reputation_last_computed_at)->not->toBeNull();
+});
+
+it('GET /api/agents/{id}/profile returns owner + domain + recent runs', function () {
+    seedRun($this->agent->id, $this->project->id, 'completed');
+
+    $response = $this->actingAs($this->user)
+        ->getJson("/api/agents/{$this->agent->id}/profile");
+
+    $response->assertOk()
+        ->assertJsonPath('data.name', 'Repper')
+        ->assertJsonPath('data.owner.email', 'rep@test.com')
+        ->assertJsonPath('data.total_invocations', 1);
+});

--- a/tests/Feature/AgentRoutingTest.php
+++ b/tests/Feature/AgentRoutingTest.php
@@ -1,0 +1,137 @@
+<?php
+
+use App\Models\Agent;
+use App\Models\ExecutionRun;
+use App\Models\Project;
+use App\Models\Skill;
+use App\Models\User;
+use App\Services\AgentRoutingService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->service = app(AgentRoutingService::class);
+
+    $this->user = User::firstOrCreate(
+        ['email' => 'routing@test.com'],
+        ['name' => 'Routing', 'password' => bcrypt('password')],
+    );
+
+    $this->project = Project::create([
+        'name' => 'Route Project',
+        'path' => '/tmp/route',
+        'providers' => ['claude'],
+        'owner_id' => $this->user->id,
+    ]);
+
+    $this->billingAgent = Agent::create([
+        'name' => 'Billing Bot',
+        'role' => 'finance',
+        'base_instructions' => 'handle billing',
+        'model' => 'claude-sonnet-4-6',
+        'objective_template' => 'x',
+        'success_criteria' => [],
+        'max_iterations' => 5,
+        'planning_mode' => 'plan_then_act',
+        'loop_condition' => 'goal_met',
+        'owner_user_id' => $this->user->id,
+    ]);
+
+    $this->searchAgent = Agent::create([
+        'name' => 'Search Bot',
+        'role' => 'research',
+        'base_instructions' => 'do research',
+        'model' => 'claude-sonnet-4-6',
+        'objective_template' => 'x',
+        'success_criteria' => [],
+        'max_iterations' => 5,
+        'planning_mode' => 'plan_then_act',
+        'loop_condition' => 'goal_met',
+        'owner_user_id' => $this->user->id,
+    ]);
+
+    $billingSkill = Skill::create([
+        'project_id' => $this->project->id,
+        'name' => 'Invoice Generation',
+        'slug' => 'invoice-gen',
+        'description' => 'Generates subscription invoices and refund notices.',
+        'body' => '...',
+    ]);
+    $searchSkill = Skill::create([
+        'project_id' => $this->project->id,
+        'name' => 'Web Search',
+        'slug' => 'web-search',
+        'description' => 'Queries the web and summarizes results.',
+        'body' => '...',
+    ]);
+
+    DB::table('agent_skill')->insert([
+        ['project_id' => $this->project->id, 'agent_id' => $this->billingAgent->id, 'skill_id' => $billingSkill->id],
+        ['project_id' => $this->project->id, 'agent_id' => $this->searchAgent->id, 'skill_id' => $searchSkill->id],
+    ]);
+});
+
+it('ranks billing agent higher for billing questions', function () {
+    $results = $this->service->rank('Who should I ask about an invoice refund?');
+
+    expect($results)->not->toBeEmpty()
+        ->and($results[0]['agent_id'])->toBe($this->billingAgent->id)
+        ->and($results[0]['reasoning'])->toContain('skill overlap');
+});
+
+it('ranks search agent higher for research questions', function () {
+    $results = $this->service->rank('Can someone summarize recent web research on this?');
+
+    expect($results[0]['agent_id'])->toBe($this->searchAgent->id);
+});
+
+it('boosts by past-run overlap', function () {
+    ExecutionRun::create([
+        'project_id' => $this->project->id,
+        'agent_id' => $this->billingAgent->id,
+        'input' => ['message' => 'Reconcile the quarterly statements for merchants'],
+        'status' => 'completed',
+    ]);
+
+    $results = $this->service->rank('quarterly statements merchants');
+
+    expect($results[0]['agent_id'])->toBe($this->billingAgent->id)
+        ->and($results[0]['reasoning'])->toContain('past-run');
+});
+
+it('returns empty array when question has no meaningful tokens', function () {
+    $results = $this->service->rank('the');
+
+    expect($results)->toBeEmpty();
+});
+
+it('scopes by project when project_id is given', function () {
+    $otherProject = Project::create([
+        'name' => 'Other',
+        'path' => '/tmp/other',
+        'providers' => ['claude'],
+        'owner_id' => $this->user->id,
+    ]);
+
+    DB::table('project_agent')->insert([
+        'project_id' => $otherProject->id,
+        'agent_id' => $this->billingAgent->id,
+        'is_enabled' => true,
+    ]);
+
+    $results = $this->service->rank('invoice refund', $otherProject->id);
+
+    expect($results[0]['agent_id'])->toBe($this->billingAgent->id);
+    expect(count($results))->toBe(1);
+});
+
+it('POST /api/agents/route returns ranked matches', function () {
+    $response = $this->actingAs($this->user)->postJson('/api/agents/route', [
+        'question' => 'Who handles invoice refunds?',
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('data.0.agent_id', $this->billingAgent->id);
+});

--- a/tests/Feature/ProjectRoleAssignmentTest.php
+++ b/tests/Feature/ProjectRoleAssignmentTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\ProjectRoleAssignment;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->admin = User::firstOrCreate(
+        ['email' => 'role-admin@test.com'],
+        ['name' => 'Role Admin', 'password' => bcrypt('password')],
+    );
+
+    $this->member = User::firstOrCreate(
+        ['email' => 'member@test.com'],
+        ['name' => 'Member', 'password' => bcrypt('password')],
+    );
+
+    $this->org = Organization::create(['name' => 'Role Org']);
+    $this->admin->current_organization_id = $this->org->id;
+    $this->admin->save();
+
+    \DB::table('organization_user')->insert([
+        'organization_id' => $this->org->id,
+        'user_id' => $this->admin->id,
+        'role' => 'admin',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $this->project = Project::create([
+        'name' => 'Role Project',
+        'path' => '/tmp/role',
+        'providers' => ['claude'],
+        'owner_id' => $this->admin->id,
+        'organization_id' => $this->org->id,
+    ]);
+});
+
+it('creates a DRI assignment with scope', function () {
+    $response = $this->actingAs($this->admin)
+        ->postJson("/api/projects/{$this->project->id}/role-assignments", [
+            'user_id' => $this->member->id,
+            'role' => 'dri',
+            'scope' => 'merchant-churn',
+        ]);
+
+    $response->assertCreated()
+        ->assertJsonPath('data.role', 'dri')
+        ->assertJsonPath('data.scope', 'merchant-churn')
+        ->assertJsonPath('data.user.email', 'member@test.com');
+});
+
+it('lists active assignments and filters out ended ones', function () {
+    $activeId = ProjectRoleAssignment::create([
+        'project_id' => $this->project->id,
+        'user_id' => $this->member->id,
+        'role' => 'ic',
+        'started_at' => now()->subDay(),
+    ])->id;
+
+    ProjectRoleAssignment::create([
+        'project_id' => $this->project->id,
+        'user_id' => $this->member->id,
+        'role' => 'coach',
+        'started_at' => now()->subMonth(),
+        'ended_at' => now()->subWeek(),
+    ]);
+
+    $response = $this->actingAs($this->admin)
+        ->getJson("/api/projects/{$this->project->id}/role-assignments");
+
+    $response->assertOk();
+    $ids = collect($response->json('data'))->pluck('id')->all();
+
+    expect($ids)->toBe([$activeId]);
+});
+
+it('a user can hold multiple active roles', function () {
+    $this->actingAs($this->admin)
+        ->postJson("/api/projects/{$this->project->id}/role-assignments", [
+            'user_id' => $this->member->id, 'role' => 'ic',
+        ])->assertCreated();
+
+    $this->actingAs($this->admin)
+        ->postJson("/api/projects/{$this->project->id}/role-assignments", [
+            'user_id' => $this->member->id, 'role' => 'coach',
+        ])->assertCreated();
+
+    expect(ProjectRoleAssignment::where('user_id', $this->member->id)->count())->toBe(2);
+});
+
+it('destroy marks an assignment as ended instead of deleting the row', function () {
+    $assignment = ProjectRoleAssignment::create([
+        'project_id' => $this->project->id,
+        'user_id' => $this->member->id,
+        'role' => 'dri',
+        'scope' => 'pricing',
+        'started_at' => now()->subWeek(),
+    ]);
+
+    $this->actingAs($this->admin)
+        ->deleteJson("/api/projects/{$this->project->id}/role-assignments/{$assignment->id}")
+        ->assertOk();
+
+    expect(ProjectRoleAssignment::find($assignment->id)->ended_at)->not->toBeNull();
+});
+
+it('rejects unknown role values', function () {
+    $response = $this->actingAs($this->admin)
+        ->postJson("/api/projects/{$this->project->id}/role-assignments", [
+            'user_id' => $this->member->id,
+            'role' => 'lead',
+        ]);
+
+    $response->assertStatus(422);
+});
+
+it('update can transfer ownership of a role to a different scope', function () {
+    $assignment = ProjectRoleAssignment::create([
+        'project_id' => $this->project->id,
+        'user_id' => $this->member->id,
+        'role' => 'dri',
+        'scope' => 'pricing',
+    ]);
+
+    $this->actingAs($this->admin)
+        ->putJson("/api/projects/{$this->project->id}/role-assignments/{$assignment->id}", [
+            'scope' => 'merchant-churn',
+        ])->assertOk();
+
+    expect($assignment->fresh()->scope)->toBe('merchant-churn');
+});

--- a/tests/Feature/WorkFeedTest.php
+++ b/tests/Feature/WorkFeedTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use App\Models\Agent;
+use App\Models\ExecutionRun;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::firstOrCreate(
+        ['email' => 'feed@test.com'],
+        ['name' => 'Feed', 'password' => bcrypt('password')],
+    );
+
+    $this->other = User::firstOrCreate(
+        ['email' => 'feed-other@test.com'],
+        ['name' => 'Other', 'password' => bcrypt('password')],
+    );
+
+    $this->org = Organization::create(['name' => 'Feed Org']);
+    $this->user->current_organization_id = $this->org->id;
+    $this->user->save();
+
+    $this->project = Project::create([
+        'name' => 'Feed Project',
+        'path' => '/tmp/feed',
+        'providers' => ['claude'],
+        'owner_id' => $this->user->id,
+        'organization_id' => $this->org->id,
+    ]);
+
+    $this->agent = Agent::create([
+        'name' => 'Feeder',
+        'role' => 'worker',
+        'base_instructions' => 'hi',
+        'model' => 'claude-sonnet-4-6',
+        'objective_template' => 'x',
+        'success_criteria' => [],
+        'max_iterations' => 5,
+        'planning_mode' => 'plan_then_act',
+        'loop_condition' => 'goal_met',
+        'owner_user_id' => $this->user->id,
+    ]);
+});
+
+function run(array $overrides = []): ExecutionRun
+{
+    return ExecutionRun::create(array_merge([
+        'project_id' => test()->project->id,
+        'agent_id' => test()->agent->id,
+        'input' => ['message' => 'Test work'],
+        'status' => 'completed',
+        'visibility' => 'org',
+        'created_by' => test()->user->id,
+    ], $overrides));
+}
+
+it('work feed only surfaces team + org runs in current org', function () {
+    $orgRun = run(['visibility' => 'org']);
+    $teamRun = run(['visibility' => 'team']);
+    run(['visibility' => 'private']); // should be excluded
+
+    // Run in a different org — should be excluded
+    $otherOrg = Organization::create(['name' => 'Other Org']);
+    $otherProject = Project::create([
+        'name' => 'Other', 'path' => '/tmp/other', 'providers' => ['claude'],
+        'owner_id' => $this->other->id, 'organization_id' => $otherOrg->id,
+    ]);
+    ExecutionRun::create([
+        'project_id' => $otherProject->id,
+        'agent_id' => $this->agent->id,
+        'input' => ['message' => 'foreign'],
+        'status' => 'completed',
+        'visibility' => 'org',
+        'created_by' => $this->other->id,
+    ]);
+
+    $response = $this->actingAs($this->user)->getJson('/api/work-feed');
+
+    $response->assertOk();
+    $ids = collect($response->json('data'))->pluck('id')->all();
+
+    expect($ids)->toContain($orgRun->id)
+        ->and($ids)->toContain($teamRun->id)
+        ->and(count($ids))->toBe(2);
+});
+
+it('work feed excludes running/pending runs', function () {
+    run(['status' => 'running', 'visibility' => 'org']);
+    run(['status' => 'pending', 'visibility' => 'org']);
+    run(['status' => 'completed', 'visibility' => 'org']);
+
+    $response = $this->actingAs($this->user)->getJson('/api/work-feed');
+
+    expect(count($response->json('data')))->toBe(1);
+});
+
+it('fork creates a new pending private run linked to the original', function () {
+    $original = run(['input' => ['message' => 'Fork me'], 'visibility' => 'org']);
+
+    $response = $this->actingAs($this->other)
+        ->postJson("/api/runs/{$original->id}/fork");
+
+    $response->assertCreated();
+    $forkedId = $response->json('data.id');
+    $forked = ExecutionRun::find($forkedId);
+
+    expect($forked->status)->toBe('pending')
+        ->and($forked->visibility)->toBe('private')
+        ->and($forked->forked_from_run_id)->toBe($original->id)
+        ->and($forked->created_by)->toBe($this->other->id)
+        ->and($forked->input)->toBe(['message' => 'Fork me']);
+});
+
+it('fork is blocked for private runs of other users', function () {
+    $privateRun = run(['visibility' => 'private']);
+
+    $this->actingAs($this->other)
+        ->postJson("/api/runs/{$privateRun->id}/fork")
+        ->assertForbidden();
+});
+
+it('visibility can be changed only by the creator', function () {
+    $r = run(['visibility' => 'private']);
+
+    $this->actingAs($this->other)
+        ->putJson("/api/runs/{$r->id}/visibility", ['visibility' => 'org'])
+        ->assertForbidden();
+
+    $this->actingAs($this->user)
+        ->putJson("/api/runs/{$r->id}/visibility", ['visibility' => 'org'])
+        ->assertOk();
+
+    expect($r->fresh()->visibility)->toBe('org');
+});

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -45,6 +45,9 @@ import { Observability } from '@/pages/Observability'
 import { MobileApprovals } from '@/pages/MobileApprovals'
 import { Federation } from '@/pages/Federation'
 import { SharedCompose } from '@/pages/SharedCompose'
+import { AgentProfile } from '@/pages/AgentProfile'
+import { AgentDirectory } from '@/pages/AgentDirectory'
+import { WorkFeed } from '@/pages/WorkFeed'
 
 function AppContent() {
   const { isOpen, close } = useCommandPalette()
@@ -105,8 +108,11 @@ function AppContent() {
                   <Route path="/skills/:id" element={<SkillEditor />} />
                   <Route path="/projects/:id/workflows" element={<Workflows />} />
                   <Route path="/agents" element={<Agents />} />
+                  <Route path="/agents/directory" element={<AgentDirectory />} />
                   <Route path="/agents/new" element={<AgentBuilder />} />
                   <Route path="/agents/:id" element={<AgentBuilder />} />
+                  <Route path="/agents/:id/profile" element={<AgentProfile />} />
+                  <Route path="/work-feed" element={<WorkFeed />} />
                   <Route path="/library" element={<Library />} />
                   {/* <Route path="/marketplace" element={<Marketplace />} /> */}
                   <Route path="/playground" element={<Playground />} />

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -1024,6 +1024,120 @@ export const importFromProvider = (projectId: number, path: string, provider?: s
 export const fetchModels = () =>
   api.get<{ data: ModelGroup[] }>('/models').then((r) => r.data.data)
 
+// Phase 5: Social layer
+export interface AgentProfile {
+  id: number
+  uuid: string
+  name: string
+  slug: string
+  icon: string | null
+  role: string
+  description: string | null
+  owner: { id: number; name: string; email: string } | null
+  reputation_score: number | null
+  reputation_last_computed_at: string | null
+  domain_summary: string
+  skill_slugs: string[]
+  total_invocations: number
+  recent_runs: Array<{
+    id: number
+    uuid: string
+    status: string
+    created_at: string
+    total_tokens: number
+    total_duration_ms: number
+  }>
+}
+
+export interface AgentRankMatch {
+  agent_id: number
+  slug: string
+  name: string
+  icon: string | null
+  role: string
+  score: number
+  reasoning: string
+  reputation_score: number | null
+  owner: { id: number; name: string } | null
+}
+
+export interface WorkFeedEntry {
+  id: number
+  uuid: string
+  status: string
+  visibility: 'private' | 'team' | 'org'
+  created_at: string
+  agent: {
+    id: number
+    name: string
+    slug: string
+    icon: string | null
+    owner: { id: number; name: string } | null
+  } | null
+  creator: { id: number; name: string } | null
+  input_summary: string
+  total_tokens: number
+  halt_reason: string | null
+}
+
+export interface ProjectRoleAssignment {
+  id: number
+  project_id: number
+  user_id: number
+  role: 'ic' | 'dri' | 'coach'
+  scope: string | null
+  started_at: string | null
+  ended_at: string | null
+  user?: { id: number; name: string; email: string }
+}
+
+export const fetchAgentProfile = (id: number) =>
+  api.get<{ data: AgentProfile }>(`/agents/${id}/profile`).then((r) => r.data.data)
+
+export const routeAgents = (question: string, projectId?: number) =>
+  api
+    .post<{ data: AgentRankMatch[] }>('/agents/route', {
+      question,
+      project_id: projectId,
+    })
+    .then((r) => r.data.data)
+
+export const fetchWorkFeed = (params: { agent_id?: number; user_id?: number; project_id?: number; per_page?: number } = {}) =>
+  api
+    .get<{ data: WorkFeedEntry[]; meta: { current_page: number; last_page: number; total: number } }>(
+      '/work-feed',
+      { params },
+    )
+    .then((r) => r.data)
+
+export const forkRun = (runId: number) =>
+  api
+    .post<{ data: { id: number; uuid: string; forked_from_run_id: number } }>(
+      `/runs/${runId}/fork`,
+    )
+    .then((r) => r.data.data)
+
+export const setRunVisibility = (runId: number, visibility: 'private' | 'team' | 'org') =>
+  api
+    .put<{ data: { visibility: string } }>(`/runs/${runId}/visibility`, { visibility })
+    .then((r) => r.data.data)
+
+export const fetchProjectRoles = (projectId: number) =>
+  api
+    .get<{ data: ProjectRoleAssignment[] }>(`/projects/${projectId}/role-assignments`)
+    .then((r) => r.data.data)
+
+export const createProjectRole = (
+  projectId: number,
+  data: { user_id: number; role: 'ic' | 'dri' | 'coach'; scope?: string },
+) =>
+  api
+    .post<{ data: ProjectRoleAssignment }>(`/projects/${projectId}/role-assignments`, data)
+    .then((r) => r.data.data)
+
+export const endProjectRole = (projectId: number, assignmentId: number) =>
+  api.delete(`/projects/${projectId}/role-assignments/${assignmentId}`)
+
 // Skill staleness
 export interface StalenessStatus {
   is_stale: boolean

--- a/ui/src/components/projects/RoleMap.tsx
+++ b/ui/src/components/projects/RoleMap.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useState } from 'react'
+import {
+  fetchProjectRoles,
+  createProjectRole,
+  endProjectRole,
+  type ProjectRoleAssignment,
+} from '@/api/client'
+
+interface Props {
+  projectId: number
+}
+
+const ROLE_LABEL: Record<ProjectRoleAssignment['role'], string> = {
+  ic: 'IC',
+  dri: 'DRI',
+  coach: 'Coach',
+}
+
+const ROLE_DESC: Record<ProjectRoleAssignment['role'], string> = {
+  ic: 'Owns a capability',
+  dri: 'Owns a cross-cutting outcome',
+  coach: 'Player-coach (craft + people)',
+}
+
+export function RoleMap({ projectId }: Props) {
+  const [assignments, setAssignments] = useState<ProjectRoleAssignment[]>([])
+  const [loading, setLoading] = useState(true)
+  const [showForm, setShowForm] = useState(false)
+  const [userId, setUserId] = useState('')
+  const [role, setRole] = useState<ProjectRoleAssignment['role']>('ic')
+  const [scope, setScope] = useState('')
+
+  const load = () => {
+    setLoading(true)
+    fetchProjectRoles(projectId)
+      .then(setAssignments)
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(load, [projectId])
+
+  const handleAdd = async () => {
+    if (!userId.trim()) return
+    await createProjectRole(projectId, {
+      user_id: parseInt(userId),
+      role,
+      scope: scope || undefined,
+    })
+    setUserId('')
+    setScope('')
+    setShowForm(false)
+    load()
+  }
+
+  const handleEnd = async (id: number) => {
+    await endProjectRole(projectId, id)
+    load()
+  }
+
+  const grouped: Record<string, ProjectRoleAssignment[]> = { ic: [], dri: [], coach: [] }
+  for (const a of assignments) grouped[a.role]?.push(a)
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Role map
+        </h3>
+        <button
+          onClick={() => setShowForm(!showForm)}
+          className="text-xs px-2.5 py-1 border border-border rounded hover:bg-muted/40"
+        >
+          {showForm ? 'Cancel' : '+ Add'}
+        </button>
+      </div>
+
+      {showForm && (
+        <div className="border border-border rounded p-3 space-y-2">
+          <div className="grid grid-cols-2 gap-2">
+            <input
+              type="number"
+              value={userId}
+              onChange={(e) => setUserId(e.target.value)}
+              placeholder="User ID"
+              className="px-2 py-1 text-xs border border-input bg-background rounded"
+            />
+            <select
+              value={role}
+              onChange={(e) => setRole(e.target.value as ProjectRoleAssignment['role'])}
+              className="px-2 py-1 text-xs border border-input bg-background rounded"
+            >
+              <option value="ic">IC — {ROLE_DESC.ic}</option>
+              <option value="dri">DRI — {ROLE_DESC.dri}</option>
+              <option value="coach">Coach — {ROLE_DESC.coach}</option>
+            </select>
+          </div>
+          <input
+            type="text"
+            value={scope}
+            onChange={(e) => setScope(e.target.value)}
+            placeholder="Scope (optional, e.g. merchant-churn)"
+            className="w-full px-2 py-1 text-xs border border-input bg-background rounded"
+          />
+          <button
+            onClick={handleAdd}
+            disabled={!userId.trim()}
+            className="text-xs px-3 py-1 bg-primary text-primary-foreground rounded disabled:opacity-50"
+          >
+            Assign
+          </button>
+        </div>
+      )}
+
+      {loading ? (
+        <p className="text-xs text-muted-foreground animate-pulse">Loading…</p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          {(['ic', 'dri', 'coach'] as const).map((r) => (
+            <div key={r} className="border border-border rounded p-3">
+              <div className="text-xs font-semibold">{ROLE_LABEL[r]}</div>
+              <div className="text-[10px] text-muted-foreground mb-2">{ROLE_DESC[r]}</div>
+              {grouped[r].length === 0 ? (
+                <p className="text-xs text-muted-foreground/60">—</p>
+              ) : (
+                <ul className="space-y-1">
+                  {grouped[r].map((a) => (
+                    <li key={a.id} className="flex items-center gap-1 text-xs">
+                      <span className="truncate flex-1">
+                        {a.user?.name ?? `user #${a.user_id}`}
+                        {a.scope && <span className="text-muted-foreground"> · {a.scope}</span>}
+                      </span>
+                      <button
+                        onClick={() => handleEnd(a.id)}
+                        className="text-[10px] text-muted-foreground hover:text-destructive"
+                        title="End assignment"
+                      >
+                        ×
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/pages/AgentDirectory.tsx
+++ b/ui/src/pages/AgentDirectory.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { routeAgents, type AgentRankMatch } from '@/api/client'
+import { fetchAgents } from '@/api/client'
+import type { Agent } from '@/types'
+
+export function AgentDirectory() {
+  const [agents, setAgents] = useState<Agent[]>([])
+  const [question, setQuestion] = useState('')
+  const [matches, setMatches] = useState<AgentRankMatch[] | null>(null)
+  const [routing, setRouting] = useState(false)
+
+  useEffect(() => {
+    fetchAgents().then(setAgents).catch(() => {})
+  }, [])
+
+  const handleAsk = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!question.trim()) return
+    setRouting(true)
+    try {
+      const results = await routeAgents(question)
+      setMatches(results)
+    } finally {
+      setRouting(false)
+    }
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto p-6 space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Agent directory</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Browse agents in your organization or ask who should help with something specific.
+        </p>
+      </header>
+
+      <form
+        onSubmit={handleAsk}
+        className="flex gap-2 border border-border rounded p-3 bg-muted/20"
+      >
+        <input
+          type="text"
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          placeholder="Who should I ask about…"
+          className="flex-1 px-2.5 py-1.5 text-sm border border-input bg-background rounded"
+        />
+        <button
+          type="submit"
+          disabled={routing || !question.trim()}
+          className="text-xs px-3 py-1.5 bg-primary text-primary-foreground rounded disabled:opacity-50"
+        >
+          {routing ? 'Routing…' : 'Ask'}
+        </button>
+      </form>
+
+      {matches !== null && (
+        <section>
+          <h2 className="text-sm font-semibold uppercase text-muted-foreground mb-2">
+            Best matches
+          </h2>
+          {matches.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No matches found.</p>
+          ) : (
+            <ul className="space-y-2">
+              {matches.map((m) => (
+                <li key={m.agent_id} className="border border-border rounded p-3">
+                  <div className="flex items-start gap-3">
+                    <Link
+                      to={`/agents/${m.agent_id}/profile`}
+                      className="text-sm font-medium text-primary hover:underline"
+                    >
+                      {m.icon && <span className="mr-1">{m.icon}</span>}
+                      {m.name}
+                    </Link>
+                    <span className="text-xs text-muted-foreground">{m.role}</span>
+                    <span className="ml-auto text-xs font-mono text-muted-foreground">
+                      score {m.score.toFixed(2)}
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">{m.reasoning}</p>
+                  {m.owner && (
+                    <p className="text-[11px] text-muted-foreground mt-0.5">
+                      owner: {m.owner.name}
+                      {m.reputation_score !== null && ` · rep ${m.reputation_score}`}
+                    </p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      )}
+
+      <section>
+        <h2 className="text-sm font-semibold uppercase text-muted-foreground mb-2">
+          All agents
+        </h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {agents.map((a) => (
+            <Link
+              key={a.id}
+              to={`/agents/${a.id}/profile`}
+              className="border border-border rounded p-3 hover:bg-muted/30 transition-colors"
+            >
+              <div className="text-sm font-medium">
+                {a.icon && <span className="mr-1">{a.icon}</span>}
+                {a.name}
+              </div>
+              <div className="text-xs text-muted-foreground mt-0.5">{a.role}</div>
+              {a.description && (
+                <p className="text-xs text-muted-foreground/80 mt-1 line-clamp-2">{a.description}</p>
+              )}
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/ui/src/pages/AgentProfile.tsx
+++ b/ui/src/pages/AgentProfile.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { fetchAgentProfile, type AgentProfile } from '@/api/client'
+
+export function AgentProfile() {
+  const { id } = useParams<{ id: string }>()
+  const [profile, setProfile] = useState<AgentProfile | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!id) return
+    fetchAgentProfile(parseInt(id))
+      .then(setProfile)
+      .catch(() => setError('Failed to load profile'))
+  }, [id])
+
+  if (error) return <div className="p-6 text-sm text-destructive">{error}</div>
+  if (!profile) return <div className="p-6 text-sm text-muted-foreground animate-pulse">Loading…</div>
+
+  const reputation = profile.reputation_score !== null
+    ? `${Number(profile.reputation_score).toFixed(1)}`
+    : '—'
+
+  return (
+    <div className="max-w-4xl mx-auto p-6 space-y-6">
+      <header className="flex items-start gap-4">
+        <div className="flex-1">
+          <h1 className="text-2xl font-semibold">
+            {profile.icon && <span className="mr-2">{profile.icon}</span>}
+            {profile.name}
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1">{profile.description ?? '—'}</p>
+          <p className="text-xs text-muted-foreground mt-2">{profile.domain_summary}</p>
+        </div>
+        <div className="shrink-0 text-right">
+          <div className="text-xs text-muted-foreground">Reputation</div>
+          <div className="text-2xl font-mono font-semibold">{reputation}</div>
+          <div className="text-[10px] text-muted-foreground">
+            {profile.reputation_last_computed_at
+              ? new Date(profile.reputation_last_computed_at).toLocaleDateString()
+              : 'not yet computed'}
+          </div>
+        </div>
+      </header>
+
+      <section className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="border border-border rounded p-3">
+          <div className="text-xs font-semibold uppercase text-muted-foreground mb-1">Owner</div>
+          {profile.owner ? (
+            <div>
+              <div className="text-sm">{profile.owner.name}</div>
+              <div className="text-xs text-muted-foreground">{profile.owner.email}</div>
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground">No owner set</div>
+          )}
+        </div>
+        <div className="border border-border rounded p-3">
+          <div className="text-xs font-semibold uppercase text-muted-foreground mb-1">Invocations</div>
+          <div className="text-2xl font-mono">{profile.total_invocations}</div>
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-sm font-semibold uppercase text-muted-foreground mb-2">
+          Recent public runs
+        </h2>
+        {profile.recent_runs.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No public runs yet.</p>
+        ) : (
+          <ul className="divide-y divide-border border border-border rounded">
+            {profile.recent_runs.map((r) => (
+              <li key={r.id} className="p-3 flex items-center gap-3 text-sm">
+                <Link to={`/runs/${r.id}`} className="text-primary hover:underline font-mono text-xs">
+                  #{r.id}
+                </Link>
+                <span className="px-1.5 py-0.5 rounded bg-muted/60 text-[10px] font-mono">
+                  {r.status}
+                </span>
+                <span className="text-muted-foreground text-xs flex-1">
+                  {new Date(r.created_at).toLocaleString()}
+                </span>
+                <span className="text-xs text-muted-foreground">{r.total_tokens} tok</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/ui/src/pages/ProjectDetail.tsx
+++ b/ui/src/pages/ProjectDetail.tsx
@@ -32,6 +32,7 @@ import { ImportLibraryModal } from '@/components/library/ImportLibraryModal'
 import { SkillsShImportModal } from '@/components/library/SkillsShImportModal'
 import { AgentsTab } from '@/components/agents/AgentsTab'
 import { AgentTeamTab } from '@/components/agents/AgentTeamTab'
+import { RoleMap } from '@/components/projects/RoleMap'
 import { ConnectionsTab } from '@/components/integrations/ConnectionsTab'
 import VisualizationTab from '@/components/visualization/VisualizationTab'
 import { SchedulesTab } from '@/components/schedules/SchedulesTab'
@@ -376,7 +377,12 @@ export function ProjectDetail() {
       )}
 
       {activeTab === 'team' && (
-        <AgentTeamTab projectId={project.id} />
+        <div className="space-y-6">
+          <AgentTeamTab projectId={project.id} />
+          <div className="bg-card elevation-1 rounded-lg p-4">
+            <RoleMap projectId={project.id} />
+          </div>
+        </div>
       )}
 
       {activeTab === 'artifacts' && (

--- a/ui/src/pages/WorkFeed.tsx
+++ b/ui/src/pages/WorkFeed.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { fetchWorkFeed, forkRun, type WorkFeedEntry } from '@/api/client'
+import { useAppStore } from '@/store/useAppStore'
+
+export function WorkFeed() {
+  const [entries, setEntries] = useState<WorkFeedEntry[]>([])
+  const [loading, setLoading] = useState(true)
+  const [forking, setForking] = useState<number | null>(null)
+  const showToast = useAppStore((s) => s.showToast)
+
+  useEffect(() => {
+    fetchWorkFeed()
+      .then((res) => setEntries(res.data))
+      .finally(() => setLoading(false))
+  }, [])
+
+  const handleFork = async (runId: number) => {
+    setForking(runId)
+    try {
+      const result = await forkRun(runId)
+      showToast(`Forked as run #${result.id}`)
+    } catch {
+      showToast('Failed to fork', 'error')
+    } finally {
+      setForking(null)
+    }
+  }
+
+  if (loading) {
+    return <div className="p-6 text-sm text-muted-foreground animate-pulse">Loading feed…</div>
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto p-6 space-y-4">
+      <header>
+        <h1 className="text-2xl font-semibold">Work feed</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Recent public runs across your organization — fork any of them to start from the same context.
+        </p>
+      </header>
+
+      {entries.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          Nothing here yet. Runs become visible once someone marks them <strong>team</strong> or{' '}
+          <strong>org</strong>.
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {entries.map((entry) => (
+            <li key={entry.id} className="border border-border rounded p-3 space-y-2">
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <span className="font-mono">#{entry.id}</span>
+                <span className="px-1.5 py-0.5 rounded bg-muted/60 font-mono">
+                  {entry.status}
+                </span>
+                <span>· {new Date(entry.created_at).toLocaleString()}</span>
+                {entry.halt_reason && (
+                  <span className="text-destructive">· halted: {entry.halt_reason}</span>
+                )}
+              </div>
+
+              <div className="flex items-start gap-3">
+                <div className="flex-1 min-w-0">
+                  {entry.agent && (
+                    <Link
+                      to={`/agents/${entry.agent.id}/profile`}
+                      className="text-sm font-medium text-primary hover:underline"
+                    >
+                      {entry.agent.icon && <span className="mr-1">{entry.agent.icon}</span>}
+                      {entry.agent.name}
+                    </Link>
+                  )}
+                  {entry.agent?.owner && (
+                    <span className="text-xs text-muted-foreground ml-2">
+                      · {entry.agent.owner.name}
+                    </span>
+                  )}
+                  <p className="text-sm text-foreground/90 mt-1">{entry.input_summary || '—'}</p>
+                  <p className="text-[11px] text-muted-foreground mt-1">
+                    {entry.total_tokens} tokens
+                    {entry.creator && ` · triggered by ${entry.creator.name}`}
+                  </p>
+                </div>
+                <button
+                  onClick={() => handleFork(entry.id)}
+                  disabled={forking === entry.id}
+                  className="shrink-0 text-xs px-2.5 py-1 border border-border rounded hover:bg-muted/40 disabled:opacity-50"
+                >
+                  {forking === entry.id ? 'Forking…' : 'Fork'}
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Phase 5 of the roadmap — second half of the org-design layer ([milestone #117](https://github.com/eooo-io/orkestr/milestone/117)). Agents and the runs they produce become social primitives: every agent has a named owner, a reputation, and a derived specialization; runs can be shared with teammates who can fork from them; projects declare who plays which role.

## Issue breakdown

### #542 — Agent ownership + reputation

- `agents.owner_user_id` (FK, backfilled from `created_by`)
- `agents.reputation_score` decimal(5,2) + `reputation_last_computed_at`
- `AgentReputationService::calculate` — baseline 50, +30 for completion rate, −20 for halt rate, −10 for failure rate, ±15 for skill-review signal. Returns 0 below 3 recent runs (no score > noisy score)
- `RecomputeAgentReputationJob` scheduled nightly at 03:00
- `GET /api/agents/{id}/profile` — owner, derived specialization, reputation, last 10 non-private runs, total invocations
- SPA: `/agents/:id/profile`

### #543 — Agent directory + "Who should I ask?" routing

- `AgentRoutingService::rank` — 0.7 × skill-overlap + 0.3 × past-run-overlap, question tokenized with stopword stripping
- Returns top 10 with human-readable reasoning ("40% skill overlap, 20% past-run overlap")
- `POST /api/agents/route` accepts `{question, project_id?}`
- SPA: `/agents/directory` — browse grid + routing search

### #544 — Work feed + fork run (Midjourney effect)

- `execution_runs.visibility` (private/team/org, default private)
- `execution_runs.forked_from_run_id` self-FK
- `organizations.default_run_visibility` for org-wide default
- `GET /api/work-feed` — paginated, team+org visible, scoped to caller's current org, only `completed`/`halted_guardrail` runs (no in-flight noise)
- `POST /api/runs/{id}/fork` — clones `input` + `config` into pending private run, respects visibility
- `PUT /api/runs/{id}/visibility` — creator-only
- SPA: `/work-feed`

### #545 — Three-role project metadata (IC/DRI/coach)

- `project_role_assignments` (project_id, user_id, role, scope, started_at, ended_at)
- A user can hold multiple active roles per project (IC for one scope + coach for another)
- CRUD at `/api/projects/{p}/role-assignments` — `destroy` ends instead of deleting (history preserved)
- `RoleMap.tsx` mounted in the Team tab of `ProjectDetail` with inline add/end

## Test plan

- [x] Backend: **445/445** agent/execution/skill/eval/lint/routing/reputation/feed/role tests pass
- [x] UI: `tsc --noEmit` clean
- [x] Pest: 24 new (Reputation +7, Routing +6, WorkFeed +5, Roles +6)
- [ ] Manual: run the nightly job (`php artisan schedule:test`) — reputation scores populate
- [ ] Manual: open `/agents/directory` → ask "Who should I ask about invoice refunds?" → billing agent ranks first
- [ ] Manual: trigger a run → mark visibility `team` → open `/work-feed` in another user's session → see it → fork it → new private run created
- [ ] Manual: on a project's Team tab, assign someone as DRI with scope, end their assignment, history preserved in DB

## Deferred

**Filament admin resource for role assignments** and **"prefer coaches for skill review" routing** (wire into Phase 3 regression gates). The data is there; Filament + Phase 3 wiring are straightforward follow-ups worth separate PRs.

## Dependencies

Built on Phase 4 (halted-guardrail status feeds reputation formula) and Phase 1 (ownership parallels the tuned-for-model authorial intent).

Closes #542
Closes #543
Closes #544
Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)