### PR TITLE
Docs: catch up on phases 0–6 before starting Phase 7

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -111,12 +111,21 @@ export default withMermaid(
               { text: 'Includes & Composition', link: '/guide/includes' },
               { text: 'Template Variables', link: '/guide/templates' },
               { text: 'Prompt Linting', link: '/guide/linting' },
+              { text: 'Model Staleness', link: '/guide/staleness' },
               { text: 'Version History', link: '/guide/versions' },
               { text: 'Agent Configuration', link: '/guide/agents' },
               { text: 'Agent Teams', link: '/guide/agent-teams' },
               { text: 'Agent Compose', link: '/guide/agent-compose' },
+              { text: 'Compose Preview & Sharing', link: '/guide/compose-sharing' },
               { text: 'Canvas', link: '/guide/canvas' },
               { text: 'Workflows', link: '/guide/workflows' },
+            ],
+          },
+          {
+            text: 'Quality & Safety',
+            items: [
+              { text: 'Eval Regression Gates', link: '/guide/eval-gates' },
+              { text: 'Runtime Safety Guardrails', link: '/guide/runtime-safety' },
             ],
           },
           {
@@ -131,6 +140,13 @@ export default withMermaid(
               { text: 'Execution', link: '/guide/execution' },
               { text: 'Schedules', link: '/guide/schedules' },
               { text: 'Connections', link: '/guide/connections' },
+            ],
+          },
+          {
+            text: 'Social Layer & Learning',
+            items: [
+              { text: 'Agent Social Layer', link: '/guide/social-layer' },
+              { text: 'Compound Learning', link: '/guide/compound-learning' },
             ],
           },
           {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,65 @@
 # Changelog
 
+## v1.1.0 — 2026 Roadmap (Phases 0–6)
+
+Seven phases shipped across seven PRs. Harness engineering (0–3) turned the skill editor into a quality-tracking surface; the org-design layer (4–6) made runs bounded, agents social, and learning compound. 26 new migrations, 106 new Pest tests.
+
+### Phase 0 — Quick wins ([PR #549](https://github.com/eooo-io/orkestr/pull/549))
+
+- **Inline gotcha strip** above Monaco in the skill editor shows open-gotcha counts + top critical titles without switching tabs
+- **Progressive-disclosure lint rule** — `PromptLinter::lintSkill(Skill)` overload checking `summary`, `description`, and `body` structure. Three new rules: `missing_summary`, `missing_description`, `no_progressive_disclosure`
+
+### Phase 1 — Model staleness tracking ([PR #550](https://github.com/eooo-io/orkestr/pull/550))
+
+- New columns: `skills.tuned_for_model`, `last_validated_model`, `last_validated_at`, `last_validated_eval_run_id`; `skill_versions.tuned_for_model` freezes intent per snapshot
+- **`SkillStalenessService`** returns `{is_stale, reason, tuned_for_model, last_validated_model, last_validated_at, suggested_action}` with reasons `ok`, `needs_tuning`, `needs_revalidation`, `model_deprecated`
+- **`StalenessBanner`** surfaces state above Monaco; **"Tuned for model"** dropdown in the frontmatter form
+- **Version history** shows per-version tuned-for model badges
+- Endpoints: `GET|PUT /api/skills/{skill}/staleness`
+
+### Phase 2 — Compose preview + sharing ([PR #551](https://github.com/eooo-io/orkestr/pull/551))
+
+- `AgentComposeService::compose()` gains `?string $modelOverride`; response includes `target_model`, `model_context_window`, and `skill_breakdown` with per-skill char offsets (`starts_at_char`/`ends_at_char`) for hover highlighting
+- **`ComposeShareLink`** with UUID, expiry (7-day default), snapshot-by-default, secret-scan gate via `PromptLinter`
+- **Public `GET /api/share/compose/{uuid}`** route with `throttle:30,1`, 410/404 handling, access counting
+- New SPA page **`/share/compose/:uuid`** (no sidebar, no auth); share button + modal in `AgentComposePreview`
+
+### Phase 3 — Eval regression gates ([PR #552](https://github.com/eooo-io/orkestr/pull/552))
+
+- **`ScorerInterface`** with `KeywordScorer` (deterministic) + opt-in `LlmJudgeScorer`; resolved per-suite via `skill_eval_suites.scorer` column
+- **`RunEvalSuiteJob`** (`ShouldQueue`, 900s timeout) replaces the synchronous run path; `useEvalRunStatus(runId)` polling hook
+- `skill_eval_runs` linked to `skill_version_id` + `baseline_run_id` + `delta_score`
+- **`skill_eval_gates`** table + **`SkillEvalGateService`** — `evaluateSkillSave`, `findBaselineFor` (most recent run for `(suite, model)`), `computeDelta`, `canSync`
+- `SkillController::update` returns `gate_decision`; `ProviderSyncService::syncProject` raises `EvalGateBlockedException` (409) on failing deltas
+- **`RegressionGateBanner`** + **`RegressionDeltaModal`** + **`GateConfigPanel`** in `EvalPanel`; Zustand `pendingEvalGates` slice survives navigation
+- **⚠️ `QUEUE_CONNECTION=sync` is no longer safe after this phase**
+
+### Phase 4 — Runtime safety guardrails ([PR #553](https://github.com/eooo-io/orkestr/pull/553))
+
+- **`ExecutionGuardrailService`** — loop detection (`xxh128((agent, tool, input))` signature, 6-step window, 3-repeat threshold), turn caps (org-level `max_agent_turns_per_run`, default 40), per-run token + cost budgets
+- Budget precedence: **per-run override → per-agent → org default**
+- New halt reasons: `loop_detected`, `turn_cap_exceeded`, `budget_token_exceeded`, `budget_cost_exceeded` — status `halted_guardrail`, owner notification via `agent.halt`
+- `POST /api/projects/{p}/agents/{a}/execute` accepts `token_budget` + `cost_budget_usd` overrides
+- Halt banner in `ExecutionPlayground` with human-readable reason
+
+### Phase 5 — Agent social layer ([PR #554](https://github.com/eooo-io/orkestr/pull/554))
+
+- `agents.owner_user_id` (backfilled from creator), `reputation_score`, `reputation_last_computed_at`
+- **`AgentReputationService`** formula: baseline 50 + success-rate − halt-rate − failure-rate + review signal. Scheduled nightly at 03:00
+- **`/agents/:id/profile`** page with owner, reputation, specialization, recent runs
+- **`POST /api/agents/route`** — "Who should I ask about X?" routing via skill + past-run overlap
+- **`/agents/directory`** page with routing search
+- `execution_runs.visibility` (`private`/`team`/`org`) + `forked_from_run_id` for the **work feed** at `/work-feed` with **fork** action
+- **`project_role_assignments`** (IC / DRI / coach) + `RoleMap` component in project Team tab
+
+### Phase 6 — Compound learning ([PR #555](https://github.com/eooo-io/orkestr/pull/555))
+
+- **`CapabilityDiscoveryService`** — ranks unused MCP servers, peer skills, library starters. Per-user dismissals with expiry via `capability_suggestion_dismissals`
+- **`PatternExtractionService`** + **`ExtractMemoryPatternsJob`** (daily 03:30) — scans `agent_memories` for recurring feedback, opens `skill_update_proposals` when canonical text repeats ≥3 times in 30 days
+- **`SkillPropagationService`** + **`SuggestSkillPropagationsJob`** (daily 04:00) — cross-project suggestions for high-performing skills with model-family compatibility gating
+- New SPA pages: **`/skill-proposals`** (inbox) and **`/skill-propagations`** (org-wide)
+- Endpoints for accept/reject/dismiss, `/api/skills/{id}/lineage` for provenance
+
 ## v1.0.0
 
 ### Infrastructure

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -89,6 +89,18 @@ Agents can be exported to multiple orchestration framework formats:
 
 Export from the agent configuration modal by selecting the target format. The export includes the composed instructions, tool definitions, model settings, and autonomy level.
 
+## Ownership, reputation, and the social layer
+
+Every agent has a named `owner_user_id` (who's accountable for its behavior) and a `reputation_score` computed nightly from run history. The dedicated profile page at `/agents/:id/profile` shows both, plus the agent's derived specialization (from attached skills) and its recent public runs.
+
+The full social-layer surface — profile page, org directory, "Who should I ask about X?" routing, work feed with fork, and IC/DRI/coach project roles — is documented in [Agent Social Layer](./social-layer).
+
+## Runtime safety when agents execute
+
+Each run an agent triggers is bounded by three independent guardrails: **loop detection** (same tool+input 3+ times in 6 act steps halts), **turn caps** (org-level `max_agent_turns_per_run`, default 40), and **per-run token/cost budgets** with precedence `run > agent > org`. Halted runs transition to `status=halted_guardrail` with a `halt_reason` and notify the owner. See [Runtime Safety Guardrails](./runtime-safety).
+
 ## Agents and Provider Sync
 
 When you run a provider sync, all enabled agents are composed (base instructions + custom instructions + assigned skill bodies) and included in the output alongside individual skills. See [Agent Compose](./agent-compose) for details on how composition works and [Provider Sync](./provider-sync) for how the output maps to provider files.
+
+Note: if any of the synced skills have an [eval regression gate](./eval-gates) with `block_sync=true` and the latest run is below the fail threshold, sync will fail with a 409 Conflict listing the blocking skills.

--- a/docs/guide/compose-sharing.md
+++ b/docs/guide/compose-sharing.md
@@ -1,0 +1,106 @@
+# Compose Preview + Sharing
+
+The agent compose preview shows what an agent's system prompt actually looks like after all skills, includes, variables, gotchas, and base instructions are merged. You can preview it against any model, inspect which skill contributes which section, and share a snapshot with someone outside the editor.
+
+## Opening the preview
+
+In the `AgentBuilder` or on the project detail page's agents tab, click **Compose** on any agent. The modal is also available from the command palette.
+
+## Model override
+
+The **model dropdown** in the preview header lets you re-render against any available model:
+
+- Agent default (whatever the agent or project-override is configured for)
+- Any Claude, OpenAI, Gemini, Grok, OpenRouter, or Ollama model from the model registry
+
+Changing the model updates the token usage meter to show the percentage of that model's context window consumed. A GPT-5.4 preview with 200k tokens shows ~19%, while the same content against Claude at 200k context shows 100%.
+
+```
+{
+  "target_model": "claude-sonnet-4-6",
+  "model_context_window": 200000,
+  "token_estimate": 38412
+}
+```
+
+## Skill breakdown pane
+
+Every composed response includes `skill_breakdown` — an ordered list of the skills that contributed, with character offsets into the final content:
+
+```
+{
+  "slug": "invoice-gen",
+  "name": "Invoice Generation",
+  "token_estimate": 412,
+  "starts_at_char": 1820,
+  "ends_at_char": 3210,
+  "tuned_for_model": "claude-sonnet-4-6",
+  "last_validated_model": "claude-sonnet-4-6"
+}
+```
+
+Hover any entry in the breakdown sidebar → the corresponding section of the content pane is highlighted. Each entry also shows the skill's `tuned_for_model` and `last_validated_model` badges so you can spot a stale skill contributing to a live preview at a glance.
+
+## Sharing a preview
+
+Click **Share** in the preview header. The modal has:
+
+- **Expiry** — 1 / 7 (default) / 30 / 90 days
+- **Snapshot toggle** (default on) — server freezes the current content; disabling it causes a live re-render on each public view
+
+Submitting creates a row in `compose_share_links` and returns a public URL like `/share/compose/{uuid}`.
+
+### Secret-scan gate
+
+Before creating the link, the server runs the composed output through `PromptLinter::lint()` and rejects the request with **422** if anything matches the secret patterns (API keys, tokens, private keys, connection strings, etc.):
+
+```json
+{
+  "error": "Refusing to create share link: composed output contains potential secrets.",
+  "secrets": [
+    { "rule": "secret_in_prompt", "message": "Potential Anthropic API key detected.", "line": 14 }
+  ]
+}
+```
+
+The modal surfaces the matching patterns inline so you know exactly which lines to fix.
+
+## The public view
+
+`GET /api/share/compose/{uuid}` is the first unauthenticated content-returning route beyond `/api/health` and the GitHub webhook. It's rate-limited with `throttle:30,1` (30 requests per minute per IP) and:
+
+- Returns the frozen snapshot when `is_snapshot=true`
+- Re-renders live otherwise (respecting the scope of the original creator's org context)
+- `410 Gone` when expired
+- `404` when missing
+- Increments `access_count` and `last_accessed_at` on every hit
+
+The matching SPA page is at `/share/compose/:uuid` — no sidebar, no auth guard. Read-only view of the content, token usage vs. target-model context window, and the per-skill breakdown. Safe to paste into Slack/email without leaking your Orkestr credentials.
+
+## Deleting a share
+
+Only the original creator can delete:
+
+```
+DELETE /api/share/compose/{uuid}
+```
+
+Returns `403` for anyone else.
+
+## API summary
+
+```
+POST   /api/projects/{project}/agents/{agent}/compose/share   (editor+)
+DELETE /api/share/compose/{uuid}                              (creator only)
+GET    /api/share/compose/{uuid}                              (public, throttle:30,1)
+```
+
+## Security posture
+
+See [#556](https://github.com/eooo-io/orkestr/issues/556) for the follow-up security review task. Current protections:
+
+- Snapshot mode is the default (no re-render on public hits)
+- `PromptLinter` secret-scan gate refuses creation with leakable content
+- `sanitizePayload()` strips keys prefixed `secret_*` from stored payloads
+- Ownership-only delete, editor-only creation
+- UUIDs are v4 (122 bits of entropy)

--- a/docs/guide/compound-learning.md
+++ b/docs/guide/compound-learning.md
@@ -1,0 +1,164 @@
+# Compound Learning
+
+Three features work together to grow the org's collective capability over time: **capability discovery** (what could this agent be doing?), **pattern extraction** (what should we encode from what it's already learned?), and **skill propagation** (what's working elsewhere that we should try here?).
+
+Each is a small service with a scheduled job. Together they close the loop between runtime learning and declarative config — the thesis behind Orkestr's single-source-of-truth model.
+
+## Capability discovery
+
+The "imagination gap" problem: users have capabilities configured they don't realize their agents could use.
+
+`CapabilityDiscoveryService::suggestFor(Agent)` ranks up to 6 suggestions from three sources, highest-signal first:
+
+1. **Unused MCP servers** — the agent's project has an MCP server configured but the agent isn't wired to use it. Capability is already there; it just needs a click.
+2. **Peer skills** — other agents in the same project use a skill this agent doesn't have. Social proof signal.
+3. **Library starters** — library skills tagged for the agent's role, for fresh agents without peers yet.
+
+Each suggestion has a stable `key` so users can dismiss it — the `capability_suggestion_dismissals` table records dismissals per `(user_id, agent_id, suggestion_key)` with a default 30-day expiry.
+
+```
+GET  /api/agents/{agent}/capability-suggestions
+POST /api/agents/{agent}/capability-suggestions/dismiss
+```
+
+Response shape:
+
+```json
+{
+  "key": "unused_mcp:42",
+  "type": "unused_tool",
+  "title": "Try the GitHub MCP server",
+  "rationale": "This server is configured in your project but this agent isn't using it yet.",
+  "example_prompt": "Using the GitHub tool, ",
+  "action_url": "/agents/14#mcp-servers"
+}
+```
+
+::: tip
+The dashboard widget surfacing these across your owned agents is tracked as [#560](https://github.com/eooo-io/orkestr/issues/560).
+:::
+
+## Pattern extraction → skill proposals
+
+When an agent gets told the same thing repeatedly, that feedback should become a durable skill update. `PatternExtractionService` scans `agent_memories` for recurring content and opens a `SkillUpdateProposal` when a canonical form repeats past the threshold.
+
+### The detection heuristic
+
+For each long-term or working memory in the last 30 days:
+
+1. Extract plain text from the content JSON
+2. **Canonicalize** — lowercase, drop stopwords + punctuation, keep tokens ≥3 chars
+3. Group by canonical form
+4. Open a proposal if the group has **≥3 memories**
+
+Canonicalization means `Always use pnpm!` and `please use pnpm` collapse to the same bucket, so the frequency count aggregates.
+
+Scans are **idempotent** — proposals are keyed on `(agent_id, pattern_key)`, so re-running the job updates the evidence list rather than duplicating.
+
+Scheduled at **03:30 daily** via `ExtractMemoryPatternsJob`.
+
+### The proposal inbox
+
+`/skill-proposals` lists pending proposals scoped to agents the current user owns. Each card shows:
+
+- Proposed title (usually the first 80 chars of the detected feedback)
+- Rationale (how many memories contributed)
+- Proposed body (the canonical text)
+- Target skill link (if attached; otherwise disabled)
+
+Two actions:
+
+- **Accept → new version** — creates a new `skill_version` with the proposed body, linked back to the proposal. Replaces the skill's current body.
+- **Reject (suppress 30d)** — sets `status=rejected` and `suppress_until`. The service won't reopen an identical pattern during the suppression window.
+
+API:
+
+```
+GET  /api/skill-proposals[?skill_id=X]
+GET  /api/skill-proposals/{proposal}
+POST /api/skill-proposals/{proposal}/accept   (editor+)
+POST /api/skill-proposals/{proposal}/reject   (editor+)
+```
+
+::: tip
+The in-editor banner version of this (`ProposalBanner`) is tracked as [#561](https://github.com/eooo-io/orkestr/issues/561). The inbox is live today.
+:::
+
+## Cross-project skill propagation
+
+When a skill proves valuable in one project, compatible projects in the same org should get a heads-up.
+
+`SkillPropagationService::suggestPropagations` scans skills with completed eval runs, then for each sibling project in the same org:
+
+- Skip if the target already has a same-slug skill
+- If the source has `tuned_for_model`, require a target agent in the same model family (don't propose a `claude-*`-tuned skill to a gpt-only project)
+- Score: `0.7 × normalized_eval_score + 0.3 × agent_present`
+- Threshold: `0.4`
+
+Successful matches write a row to `skill_propagations` with `status=suggested`. Scheduled at **04:00 daily** via `SuggestSkillPropagationsJob`.
+
+### The propagation inbox
+
+`/skill-propagations` lists suggestions for the user's current org, sorted by `suggestion_score`. Each card shows:
+
+- Source skill → target project → optional target agent
+- Score
+- Accept / Dismiss
+
+Accept clones the source skill into the target project with a unique slug, optionally overriding the body for project-specific context. The new skill's `modified_skill_id` points back to the propagation row.
+
+### Lineage
+
+When a skill was created via propagation, you can query its provenance:
+
+```
+GET /api/skills/{skill}/lineage
+```
+
+Returns `null` for skills that weren't propagated, otherwise:
+
+```json
+{
+  "source_skill_id": 14,
+  "source_skill_slug": "invoice-helper",
+  "source_skill_name": "Invoice Helper",
+  "source_project_id": 3,
+  "source_project_name": "Acme Billing",
+  "status": "accepted",
+  "resolved_at": "2026-04-15T10:22:00Z"
+}
+```
+
+::: tip
+The lineage strip in the skill editor is tracked as [#562](https://github.com/eooo-io/orkestr/issues/562). The endpoint is live today.
+:::
+
+## The scheduled cadence
+
+```
+03:00  RecomputeAgentReputationJob
+03:30  ExtractMemoryPatternsJob
+04:00  SuggestSkillPropagationsJob
+```
+
+All three need `QUEUE_CONNECTION != sync` to run properly.
+
+## API summary
+
+```
+# Capability discovery
+GET  /api/agents/{agent}/capability-suggestions
+POST /api/agents/{agent}/capability-suggestions/dismiss
+
+# Skill proposals
+GET  /api/skill-proposals
+GET  /api/skill-proposals/{proposal}
+POST /api/skill-proposals/{proposal}/accept      (editor+)
+POST /api/skill-proposals/{proposal}/reject      (editor+)
+
+# Propagations
+GET  /api/orgs/{organization}/skill-propagations
+POST /api/skill-propagations/{propagation}/accept     (editor+)
+POST /api/skill-propagations/{propagation}/dismiss    (editor+)
+GET  /api/skills/{skill}/lineage
+```

--- a/docs/guide/eval-gates.md
+++ b/docs/guide/eval-gates.md
@@ -1,0 +1,134 @@
+# Eval Regression Gates
+
+A skill edit can silently degrade the behavior it encodes. Eval regression gates catch that: every time you save, configured eval suites run against the new version, compare to the last-known-good baseline, and surface the delta. The gate can also block provider sync when a skill has failed a recent eval.
+
+## ⚠️ Queue configuration
+
+**`QUEUE_CONNECTION=sync` is not safe with eval gates.** Eval runs take 30s–10min and would block the HTTP request in sync mode. Use `database` (default in `.env.example`) or `redis`.
+
+## Scoring
+
+Scoring happens through a `ScorerInterface`. Two implementations ship:
+
+| Scorer | Column value | Description |
+|---|---|---|
+| `KeywordScorer` | `keyword` (default) | Extracts non-stopword keywords from `expected_behavior`, scores 0–100 based on presence in the response. Deterministic, reproducible, cheap. |
+| `LlmJudgeScorer` | `llm_judge` | Opt-in. Makes a second LLM call that grades against `grading_criteria` and returns strict JSON. Non-deterministic; costs a real API call. |
+
+Pick one per suite via the `skill_eval_suites.scorer` column. `KeywordScorer` is the default because gate decisions need to be reproducible.
+
+The scorer result shape:
+
+```json
+{
+  "score": 82,
+  "reasoning": "Matched 7 of 8 expected keywords.",
+  "signals": {
+    "scorer": "keyword",
+    "expected_keywords": ["widgets", "gears", "sprockets", "..."],
+    "matched": ["widgets", "gears", "..."],
+    "missing": ["cogs"]
+  }
+}
+```
+
+## Queued execution
+
+`EvalSuiteController::run` creates a pending `SkillEvalRun` row and dispatches `RunEvalSuiteJob` — the HTTP request returns immediately. The frontend polls `GET /api/eval-runs/{id}` via the `useEvalRunStatus(runId)` hook (3s interval) until the run leaves `pending`/`running`.
+
+The job stamps each run with the active `skill_version_id` at dispatch time, so revalidating an old version knows exactly which snapshot was graded.
+
+## Baselines
+
+**Baseline = most recent completed run for `(suite, model)`, regardless of which version it ran against.**
+
+This is intentional: revalidating the same version twice shouldn't zero out your delta. The baseline is "last known good" for a `(suite, model)` pair, not "prior version".
+
+```php
+$baseline = $gateService->findBaselineFor($skill, $suite, 'claude-sonnet-4-6');
+$delta = $gateService->computeDelta($currentRun, $baseline);
+// { overall_delta: -7.5, per_prompt: [...] }
+```
+
+## Configuring a gate
+
+The `GateConfigPanel` at the top of the skill's **Evals** tab:
+
+- **Enabled** — master switch
+- **Required suites** — which suites count toward the gate
+- **Fail threshold delta** — default `-5.00`. A run whose `delta_score` falls below this is considered a failure
+- **Auto-run on save** — dispatches runs automatically after every skill save
+- **Block sync on failure** — `ProviderSyncService::canSync` returns false for any skill whose latest run breaches the threshold
+
+Settings live in `skill_eval_gates` (one row per skill, `HasOne Skill::evalGate`).
+
+## Running the gate
+
+On every skill save, `SkillController::update` calls `SkillEvalGateService::evaluateSkillSave`:
+
+```json
+{
+  "reason": "dispatched",
+  "enqueued_run_ids": [142, 143],
+  "baseline_info": [
+    {
+      "suite_id": 7,
+      "suite_name": "Pricing behavior",
+      "run_id": 142,
+      "baseline_run_id": 110,
+      "baseline_score": 88
+    }
+  ],
+  "est_duration_seconds": 60
+}
+```
+
+`reason` can also be `no_gate`, `disabled`, `no_required_suites`, or `no_target_model`.
+
+The decision ships back in the `SkillResource` response as `additional.gate_decision` so the SPA can toast and register a pending gate.
+
+## The banner
+
+`RegressionGateBanner` mounts above Monaco next to the staleness + gotcha strips. It polls `/api/skills/{id}/eval-gate/status` and renders four states:
+
+- **Queued** — neutral. Runs dispatched, waiting for a worker.
+- **Running (n/m)** — blue/neutral with progress.
+- **Completed Δ +X.Y** — neutral green/grey, score held or improved.
+- **Completed Δ −X.Y ⚠** — red. Threshold breached. Includes a "see delta" link that opens `RegressionDeltaModal` with a per-prompt `baseline vs current` table.
+
+Pending gates are tracked in the Zustand `pendingEvalGates` slice keyed by `skillId` so navigating away and back doesn't lose the banner.
+
+## Blocking sync
+
+When `block_sync=true` and a skill's latest run has `delta_score < fail_threshold_delta`, `ProviderSyncService::syncProject` throws `EvalGateBlockedException`, which renders as **409 Conflict**:
+
+```json
+{
+  "error": "Sync blocked by one or more skill eval gates.",
+  "blocked_skills": [
+    {
+      "skill_id": 42,
+      "skill_slug": "invoice-helper",
+      "skill_name": "Invoice Helper",
+      "last_delta": -8.50,
+      "last_run_id": 118
+    }
+  ]
+}
+```
+
+The SPA surfaces these entries in a modal with links to each blocked skill's Evals tab.
+
+## API summary
+
+```
+GET   /api/skills/{skill}/eval-gate
+PUT   /api/skills/{skill}/eval-gate               (editor+)
+POST  /api/skills/{skill}/eval-gate/run-now       (editor+)
+GET   /api/skills/{skill}/eval-gate/status
+GET   /api/eval-runs/{eval_run}                   (used by polling hook)
+```
+
+## Deferred
+
+Org-level monthly eval budget cap is tracked in [#557](https://github.com/eooo-io/orkestr/issues/557). It will skip auto-run-on-save when the org exceeds its monthly spend, with a banner warning.

--- a/docs/guide/execution.md
+++ b/docs/guide/execution.md
@@ -15,7 +15,9 @@ Execution flows through four phases per iteration:
 | **Act** | Tool calls execute via MCP |
 | **Observe** | Agent evaluates results and decides whether to continue |
 
-The agent loops through these phases until a termination condition is met: goal achieved, max iterations reached, timeout, or manual stop.
+The agent loops through these phases until a termination condition is met: goal achieved, max iterations reached, timeout, manual stop, or **[runtime guardrail halt](./runtime-safety)** (loop detection, turn cap, or token/cost budget exhaustion).
+
+Halted runs transition to `status=halted_guardrail` with a human-readable `halt_reason` on the run record. The playground surfaces a red banner above the trace when this happens.
 
 ## Real-Time SSE Streaming
 
@@ -72,6 +74,25 @@ The execution detail view shows a cost breakdown table:
 | Output tokens | 3,616 |
 | Estimated cost | $0.0384 |
 | Duration | 8,420 ms |
+
+### Per-run budgets
+
+You can set a hard token or cost ceiling on individual runs via the execute endpoint:
+
+```http
+POST /api/projects/{project}/agents/{agent}/execute
+{
+  "input": { "message": "…" },
+  "token_budget": 50000,
+  "cost_budget_usd": 2.50
+}
+```
+
+Precedence: per-run override → per-agent (`run_token_budget` / `run_cost_budget_usd`) → org default (`default_run_token_budget` / `default_run_cost_budget_usd`). When a live counter crosses the resolved budget, the run halts with `halt_reason=budget_token_exceeded` or `budget_cost_exceeded` and the owner is notified. See [Runtime Safety Guardrails](./runtime-safety).
+
+### Run visibility and forking
+
+Each run has a `visibility` field (`private` default, `team`, `org`). Team- and org-visible runs show up in the [Work Feed](./social-layer#work-feed-fork) where teammates can fork them — copy `input` + `config` into a new draft run — to remix a successful prompt without starting from scratch.
 
 ## Execution Replay
 

--- a/docs/guide/linting.md
+++ b/docs/guide/linting.md
@@ -1,6 +1,6 @@
 # Prompt Linting
 
-The prompt linter analyzes your skill's body for common prompt engineering issues and suggests improvements. It runs 8 rule-based checks that catch vague instructions, conflicting directives, and structural problems.
+The prompt linter analyzes your skill's body and frontmatter for common prompt engineering issues and suggests improvements. It runs 11 rule-based checks — 8 on the body, 3 on the frontmatter — that catch vague instructions, conflicting directives, weak metadata, and structural problems.
 
 ## Using the Lint Tab
 
@@ -97,6 +97,34 @@ Flags skills that mention complexity (words like "complex", "nuanced", "edge cas
 Detects lines that are more than 85% similar to other lines in the same skill. Repeated instructions waste tokens without adding value.
 
 **Fix:** Remove the duplicate instruction.
+
+## Frontmatter rules (`lintSkill`)
+
+When the linter runs against a full `Skill` (not just a body string), it also checks the skill's metadata. These rules were added in Phase 0 alongside the progressive-disclosure structural check.
+
+### 9. Missing Summary
+
+**Severity:** Suggestion
+
+Fires when `summary` is empty. The summary is the tier-1 progressive-disclosure hint — without it, agent context indexes fall back to the longer `description` and waste tokens.
+
+**Fix:** Add a one-line summary (≤500 chars) describing when to use this skill.
+
+### 10. Missing Description
+
+**Severity:** Warning
+
+Fires when `description` is empty, under 20 chars, contains a vague word (`stuff`, `things`, `various`, `general`, `misc`), or lacks an actionable verb (generate, analyze, review, summarize, etc.). Agents use the description to decide whether to invoke the skill — vague descriptions mean the skill never triggers when needed.
+
+**Fix:** Write a concrete description with an action verb and trigger conditions.
+
+### 11. No Progressive Disclosure
+
+**Severity:** Suggestion
+
+Fires when the body is >500 chars and has no `##` or `###` heading in the first 40 lines. Long skills without section headings force the model to read everything before deciding what matters.
+
+**Fix:** Add section headings so the model can skim before committing to details.
 
 ## Linting via API
 

--- a/docs/guide/runtime-safety.md
+++ b/docs/guide/runtime-safety.md
@@ -1,0 +1,149 @@
+# Runtime Safety Guardrails
+
+Agents will find creative ways to burn your budget. Runtime guardrails catch the three most common patterns — infinite loops, runaway iteration counts, and unbounded cost — and halt the run before the damage compounds.
+
+This is distinct from the [content guardrails](./guardrails) (PII, tool allowlists, output scanning). Runtime guardrails protect the machine; content guardrails protect the output.
+
+## The halt mechanism
+
+When any guardrail fires, the run transitions to `status=halted_guardrail` with:
+
+- `halt_reason` — one of `loop_detected`, `turn_cap_exceeded`, `budget_token_exceeded`, `budget_cost_exceeded`
+- `halt_step_id` — the step that triggered it (when applicable)
+- Owner notification with `type=agent.halt` in the `notifications` table
+
+The `ExecutionPlayground` surfaces a red banner above the run header with the human-readable reason.
+
+## Loop detection
+
+The "ant death spiral" case: an agent repeats the same tool call with the same input over and over, waiting for the outcome to change. It never does.
+
+`ExecutionGuardrailService::detectLoop` hashes every tool-call signature as `xxh128((agent_id, tool_name, normalized_input))` and counts how many times the signature appears in the last **6 act steps**. If the count exceeds **3**, the run halts with `loop_detected`.
+
+Tight enough to catch genuine loops, loose enough that legitimate retries (which typically differ in input) pass cleanly.
+
+```php
+if ($reason = $guardrails->detectLoop($run, $agent->id, $toolName, $toolInput)) {
+    $guardrails->halt($run, $reason, $actStep);
+    return;
+}
+```
+
+## Turn caps
+
+Per-agent `max_iterations` already existed, but it's easy to set it high on an individual agent. The turn cap is a **org-level ceiling** that no single run can exceed:
+
+```php
+// organizations.max_agent_turns_per_run, default 40
+```
+
+Enforced at the top of each iteration:
+
+```php
+if ($reason = $guardrails->checkTurnCap($run, $iteration + 1)) {
+    $guardrails->halt($run, $reason);
+    return;
+}
+```
+
+## Per-run token + cost budgets
+
+Budgets apply to a single run's accumulated `total_tokens` and `total_cost_microcents`. Precedence:
+
+1. **Per-run override** — passed in the execute request body, written to `execution_runs.token_budget` / `cost_budget_microcents`
+2. **Per-agent** — `agents.run_token_budget` / `run_cost_budget_usd`
+3. **Org default** — `organizations.default_run_token_budget` / `default_run_cost_budget_usd`
+
+A `null` at a layer falls through to the next. If nothing is set at any layer, no budget applies.
+
+### Setting a per-run budget
+
+```
+POST /api/projects/{project}/agents/{agent}/execute
+{
+  "input": { "message": "..." },
+  "token_budget": 50000,
+  "cost_budget_usd": 2.50
+}
+```
+
+Costs are tracked in microcents on the run row: `1 USD = 1,000,000 microcents`.
+
+### The per-run cumulative check
+
+After every LLM call, `checkBudget` runs:
+
+```php
+if ($reason = $guardrails->checkBudget($freshRun)) {
+    $guardrails->halt($freshRun, $reason);
+    return;
+}
+```
+
+`$reason` is `budget_token_exceeded` when `total_tokens >= token_budget`, and `budget_cost_exceeded` when `total_cost_microcents >= cost_budget_microcents`.
+
+## This is not the per-agent cumulative budget
+
+Orkestr has two separate budget concepts:
+
+| Scope | Column | Enforced by |
+|---|---|---|
+| Per-run ceiling | `execution_runs.token_budget` / `cost_budget_microcents` (plus precedence fallbacks) | `ExecutionGuardrailService::checkBudget` |
+| Per-agent cumulative (daily/monthly) | `agents.budget_limit_usd` / `daily_budget_limit_usd` | `BudgetEnforcer` / `BudgetGuard` |
+
+The new runtime guardrails **add** to the cumulative budgets — they don't replace them. A run can be halted by either system.
+
+## Live counters
+
+`ExecutionRunResource` exposes budget state:
+
+```json
+{
+  "total_tokens": 12500,
+  "total_cost_microcents": 75000,
+  "token_budget": 50000,
+  "cost_budget_microcents": 2500000,
+  "halt_reason": null,
+  "halt_step_id": null
+}
+```
+
+The playground header shows `12,500 / 50,000 tokens` when a budget is configured.
+
+## Wiring
+
+Guardrails hook into both execution paths:
+
+- **`RunAgentJob`** — the queued path used for real runs
+- **`AgentExecutionService`** — the synchronous path used by `ExecutionController::execute`
+
+Both call `checkTurnCap` + `checkBudget` at the top of each iteration, and `detectLoop` before dispatching tool calls within the act phase.
+
+## Notifications
+
+When a run is halted, the owner receives a notification:
+
+```json
+{
+  "type": "agent.halt",
+  "title": "Agent run halted: loop detected",
+  "body": "Run #142 was halted (loop_detected). Review the execution trace.",
+  "data": {
+    "run_id": 142,
+    "halt_reason": "loop_detected",
+    "total_tokens": 18300,
+    "total_cost_microcents": 89200
+  }
+}
+```
+
+Surfaced in the bell icon + the notifications list at `/notifications`.
+
+## Defaults recap
+
+| Setting | Default | Where |
+|---|---|---|
+| Turn cap | 40 | `organizations.max_agent_turns_per_run` |
+| Loop window | 6 act steps | `ExecutionGuardrailService::LOOP_WINDOW_STEPS` |
+| Loop repeat threshold | 3 | `ExecutionGuardrailService::LOOP_REPEAT_THRESHOLD` |
+| Token / cost budgets | unset | all three precedence levels |

--- a/docs/guide/schedules.md
+++ b/docs/guide/schedules.md
@@ -86,7 +86,7 @@ Event schedules respond to internal Orkestr events -- such as a skill being upda
 ```
 
 ::: warning
-Event triggers use template variables from the event payload. Wrap dynamic values in `{{event.field_name}}` syntax within the input template.
+Event triggers use template variables from the event payload. Wrap dynamic values in <span v-pre>`{{event.field_name}}`</span> syntax within the input template.
 :::
 
 ## Managing Schedules

--- a/docs/guide/skill-editor.md
+++ b/docs/guide/skill-editor.md
@@ -6,10 +6,22 @@ The Skill Editor is where you author, test, lint, review, and manage individual 
 
 The editor is split into two panels:
 
-- **Left panel** -- Frontmatter form at the top, Monaco code editor below
-- **Right panel** -- Seven tabs for testing and management
+- **Left panel** -- Frontmatter form, status banner stack, Monaco code editor
+- **Right panel** -- Tabs for testing and management
 
 The left panel is where you write. The right panel is where you validate.
+
+## The banner stack
+
+Between the frontmatter form and the Monaco editor, the editor mounts a stack of compact status strips. Each hides when it has nothing to say, so on a clean skill you see none of them; on a problematic one, several may appear.
+
+| Banner | Source | When it shows |
+|---|---|---|
+| [`StalenessBanner`](./staleness) | `SkillStalenessService` | When the skill's `tuned_for_model` is missing, deprecated, or diverges from its last validated model |
+| `RegressionGateBanner` | [`SkillEvalGateService`](./eval-gates) | When an eval gate is configured and runs are queued, running, or outside the fail-threshold delta |
+| `InlineGotchaStrip` | `SkillGotcha` records | When the skill has open (unresolved) gotchas |
+
+Follow-up banners tracked in [#561](https://github.com/eooo-io/orkestr/issues/561) (`ProposalBanner`) and [#562](https://github.com/eooo-io/orkestr/issues/562) (lineage strip).
 
 ## Frontmatter Form
 

--- a/docs/guide/social-layer.md
+++ b/docs/guide/social-layer.md
@@ -1,0 +1,145 @@
+# Agent Social Layer
+
+When an organization has dozens of agents across multiple projects, "which agent should I ask about X?" becomes a real question. The social layer turns agents into first-class org citizens: every agent has a named owner, a reputation score, a derived specialization, and a browseable directory. Runs can be shared across the org and forked for remixing, and projects declare who plays which role.
+
+## Agent ownership
+
+Every `agents` row has:
+
+| Column | What it means |
+|---|---|
+| `owner_user_id` | The human accountable for this agent's behavior. Backfilled from `created_by` when the phase shipped. |
+| `reputation_score` | 0–100 score computed nightly. `null` when insufficient run history. |
+| `reputation_last_computed_at` | Timestamp of the last recompute. |
+
+Ownership is a trust signal. When a coworker sees output from *Billing Bot, owned by Aarav*, they know who to talk to if the output is wrong.
+
+## Reputation formula
+
+`AgentReputationService::calculate` is intentionally simple and auditable:
+
+```
+start at 50 (neutral)
++ (success_rate × 30)          // up to +30
+- (halt_rate × 20)              // up to -20 for guardrail halts
+- (failure_rate × 10)           // up to -10 for plain failures
+± (review_signal × 15)          // ±15 from skill reviews, if any
+clamp to [0, 100]
+return 0 when fewer than 3 runs in the last 30 days
+```
+
+Agents without sufficient run history return **0** rather than a noisy score — no signal beats bad signal.
+
+Recomputed via `RecomputeAgentReputationJob`, scheduled at **03:00 daily** in `routes/console.php`.
+
+## The profile page
+
+`/agents/:id/profile` surfaces the public view:
+
+- Owner name + email
+- Reputation score with last-computed timestamp
+- **Domain summary** — derived from attached skills ("Specializes in: Invoice Generation, Refund Handling, …")
+- Total invocation count
+- Last 10 non-private runs
+
+API:
+
+```
+GET /api/agents/{agent}/profile
+```
+
+## Agent directory + "Who should I ask?"
+
+`/agents/directory` is a browseable grid of all agents in the user's org with a routing search at the top.
+
+Ask "Who handles invoice refunds?" and the routing service ranks agents by:
+
+- **0.7 × skill overlap** — fraction of question tokens present in attached skill names/descriptions/summaries
+- **0.3 × past-run overlap** — fraction of tokens present in the last 30 run inputs
+
+Question tokens are lowercased, stopword-stripped, and require ≥3 characters. Results come back with human-readable reasoning:
+
+```json
+{
+  "agent_id": 14,
+  "name": "Billing Bot",
+  "score": 0.64,
+  "reasoning": "40% skill overlap, 20% past-run overlap",
+  "reputation_score": 82.5,
+  "owner": { "id": 7, "name": "Aarav" }
+}
+```
+
+API:
+
+```
+POST /api/agents/route
+{
+  "question": "Who handles invoice refunds?",
+  "project_id": 14   // optional: scope to a project
+}
+```
+
+## Work feed + fork
+
+Every run has a `visibility` field: `private` (default), `team`, or `org`. Only the creator can change it:
+
+```
+PUT /api/runs/{run}/visibility  { "visibility": "org" }
+```
+
+Org-level default is controlled by `organizations.default_run_visibility`.
+
+`/work-feed` is the chronological stream of `team` + `org` visible runs scoped to the caller's current org. Excludes `pending`/`running` runs — no in-flight noise. Each entry shows:
+
+- Agent + owner
+- Who triggered the run
+- Input summary + token count
+- Halt reason (if the run was stopped by a guardrail)
+- **Fork** button
+
+### Forking
+
+Clicking **Fork** creates a new `pending` + `private` run owned by the forker, with `input` + `config` cloned from the original and `forked_from_run_id` pointing back. You can't fork someone's private run.
+
+```
+POST /api/runs/{run}/fork
+```
+
+This is the "Midjourney effect" — when runs are visible, everyone in the org gets smarter about what's possible, and can build on each other's prompts.
+
+## Project roles (IC / DRI / coach)
+
+The `project_role_assignments` table assigns users to one of three roles on a project:
+
+| Role | What they own |
+|---|---|
+| **IC** | A capability — a discrete function of the system |
+| **DRI** | A cross-cutting outcome (use the `scope` field, e.g. "merchant-churn") |
+| **Coach** | Craft + people — mentors, reviews, unblocks |
+
+A user can hold **multiple active roles per project** — e.g. IC on one scope, coach on another.
+
+Assignments live on the Team tab of each project as a three-column role map. Adding, changing scope, and ending assignments are inline:
+
+```
+GET    /api/projects/{project}/role-assignments
+POST   /api/projects/{project}/role-assignments          (editor+)
+PUT    /api/projects/{project}/role-assignments/{id}     (editor+)
+DELETE /api/projects/{project}/role-assignments/{id}     (editor+)
+```
+
+`DELETE` sets `ended_at` instead of removing the row — history is preserved.
+
+### Why three roles
+
+This is the Dorsey-style "New AI Org Chart" model. Responsibilities naturally normalize down to these three buckets, and making them explicit feeds downstream:
+
+- **Review routing** — the Phase 7 follow-up [#559](https://github.com/eooo-io/orkestr/issues/559) wires `SkillEvalGateService` to prefer coaches in the same project for skill review assignment
+- **Capability discovery** — "Which IC owns the X capability here?"
+- **Trust** — seeing a skill authored by a known DRI carries weight
+
+## Deferred
+
+- **Filament admin resource** for role assignments — tracked in [#558](https://github.com/eooo-io/orkestr/issues/558)
+- **Coach preference in review routing** — tracked in [#559](https://github.com/eooo-io/orkestr/issues/559)

--- a/docs/guide/staleness.md
+++ b/docs/guide/staleness.md
@@ -1,0 +1,73 @@
+# Model Staleness Tracking
+
+Skills are tuned for specific models. When a model is deprecated, or when a skill's behavior hasn't been validated against a recent change, Orkestr surfaces that drift before it silently degrades your agent.
+
+## The three signals
+
+Every skill has three model-related fields:
+
+| Field | What it means |
+|---|---|
+| `model` | The model the skill *runs* against at compose time (from frontmatter). |
+| `tuned_for_model` | The model the author *designed* for — captured on first save, overrideable any time. |
+| `last_validated_model` / `last_validated_at` | The model + timestamp of the most recent successful eval run. |
+
+`tuned_for_model` is authorial intent. `last_validated_*` is evidence. When they diverge, the skill is stale.
+
+## Reasons, in priority order
+
+The staleness service returns one of four reasons:
+
+| Reason | Trigger | Color |
+|---|---|---|
+| `model_deprecated` | `tuned_for_model` appears in the deprecated list (retired Claude 3.x, GPT-4/o1, Gemini 1.5/2.x, Grok 2). | Red |
+| `needs_tuning` | `tuned_for_model` is null — the skill has never been pinned to a baseline. | Neutral |
+| `needs_revalidation` | Never validated, or `last_validated_model` differs from `tuned_for_model`, or the current `model` differs from `tuned_for_model`. | Yellow |
+| `ok` | Tuned, validated on the same model, current use matches. | Hidden |
+
+`model_deprecated` always wins. If your skill is tuned for `gpt-4` and you validated it yesterday, it's still flagged red — the model itself is retired.
+
+## The `StalenessBanner`
+
+Shows above the Monaco editor, next to the inline gotcha strip. Hidden when status is `ok`. Refetches on save.
+
+- **Red** — model is deprecated. Retune for a current model.
+- **Yellow** — needs revalidation. Run an eval suite against the tuned-for model.
+- **Neutral** — needs tuning. Pick a baseline so changes can be tracked against it.
+
+## Setting the tuned-for model
+
+The frontmatter form has a **"Tuned for model"** dropdown. It writes through `PUT /api/skills/{id}/staleness` — separate from the skill body edit, so it doesn't create a version snapshot by itself.
+
+On a skill's **first save**, the frontmatter `model` is auto-copied into `tuned_for_model` if it's null. On subsequent saves, if `tuned_for_model` is still null and `model` is populated, the same auto-seed runs. You can override any time via the dropdown.
+
+## Version history shows the baseline
+
+Each entry in `VersionHistoryPanel` shows the `tuned_for_model` that was active when the version was saved. This matters for revalidating old versions — the baseline is frozen per snapshot.
+
+## Revalidation flow
+
+1. See yellow banner → model drift detected
+2. Open the **Evals** tab → run an eval suite against the current `tuned_for_model`
+3. When the run completes, `last_validated_*` updates on the skill
+4. Banner hides (or upgrades to red if the run had poor results, depending on your gate config — see [Eval Gates](./eval-gates))
+
+## Deprecated model list
+
+Maintained as a class constant on `SkillStalenessService::DEPRECATED_MODELS`. Currently covers:
+
+- Claude 3.x (Opus/Sonnet/Haiku including `claude-3-5-*` and `claude-sonnet-4-5` / `claude-opus-4-5`)
+- GPT-3.5, GPT-4, GPT-4 Turbo, GPT-4o, GPT-4o-mini, o1-preview, o1-mini
+- Gemini 1.5 Pro/Flash, Gemini 2.0 Pro, Gemini 2.5 Pro, `gemini-pro`
+- Grok 2, Grok beta
+
+Update this list when a model is retired; any skill whose `tuned_for_model` matches will flip to red on the next staleness check.
+
+## API
+
+```
+GET  /api/skills/{skill}/staleness?current_model=claude-sonnet-4-6
+PUT  /api/skills/{skill}/staleness    # { "tuned_for_model": "claude-opus-4-6" }
+```
+
+`current_model` is optional. Pass it to detect the "tuned for X but you're running it on Y" case.

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -174,6 +174,7 @@
       "integrity": "sha512-y1IOpG6OSmTpGg/CT0YBb/EAhR2nsC18QWp9Jy8HO9iGySpcwaTvs5kHa17daP3BMTwWyaX9/1tDTDQshZzXdg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.49.2",
         "@algolia/requester-browser-xhr": "5.49.2",
@@ -2003,6 +2004,7 @@
       "integrity": "sha512-1K0wtDaRONwfhL4h8bbJ9qTjmY6rhGgRvvagXkMBsAOMNr+3Q2SffHECh9DIuNVrMA1JwA0zCwhyepgBZVakng==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.15.2",
         "@algolia/client-abtesting": "5.49.2",
@@ -2072,6 +2074,7 @@
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -2161,6 +2164,7 @@
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -2595,6 +2599,7 @@
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2819,6 +2824,7 @@
       "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tabbable": "^6.4.0"
       }
@@ -3060,6 +3066,7 @@
       "integrity": "sha512-fEnci+Immw6lKMFI8sqzjlATTyjLkRa6axrEgLV2yHTfv8r+h1wjFbV6xeRtd4rUV1cS4EpR9rwp3Rci7TRWDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.1",
         "@iconify/utils": "^3.0.2",
@@ -3732,6 +3739,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -3792,6 +3800,7 @@
       "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docsearch/css": "3.8.2",
         "@docsearch/js": "3.8.2",
@@ -3903,6 +3912,7 @@
       "integrity": "sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.30",
         "@vue/compiler-sfc": "3.5.30",

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -998,3 +998,281 @@ POST /api/import/github/import
   "project_id": "target-project-uuid"
 }
 ```
+
+---
+
+# 2026 Roadmap additions (Phases 0–6)
+
+## Model staleness (Phase 1)
+
+### Get staleness status
+
+```http
+GET /api/skills/{skill}/staleness?current_model=claude-sonnet-4-6
+```
+
+Response:
+
+```json
+{
+  "data": {
+    "is_stale": true,
+    "reason": "needs_revalidation",
+    "tuned_for_model": "claude-sonnet-4-6",
+    "last_validated_model": null,
+    "last_validated_at": null,
+    "suggested_action": "Run an eval suite against claude-sonnet-4-6 to confirm behavior."
+  }
+}
+```
+
+`reason` values: `ok`, `needs_tuning`, `needs_revalidation`, `model_deprecated`. `current_model` is optional.
+
+### Update tuned-for model
+
+```http
+PUT /api/skills/{skill}/staleness        (editor+)
+{ "tuned_for_model": "claude-opus-4-6" }
+```
+
+Returns the fresh staleness status.
+
+## Compose preview + sharing (Phase 2)
+
+### Compose with model override
+
+```http
+GET /api/projects/{project}/agents/{agent}/compose?model=gpt-5.4&depth=full
+```
+
+Response now includes `target_model`, `model_context_window`, and `skill_breakdown[]` with per-skill `starts_at_char` / `ends_at_char` offsets for UI highlighting.
+
+### Create a share link
+
+```http
+POST /api/projects/{project}/agents/{agent}/compose/share    (editor+)
+{
+  "model": null,
+  "depth": "full",
+  "expires_in_days": 7,
+  "is_snapshot": true
+}
+```
+
+Response on success (201):
+
+```json
+{
+  "data": {
+    "uuid": "…",
+    "url": "/share/compose/…",
+    "expires_at": "2026-04-26T…Z",
+    "is_snapshot": true
+  }
+}
+```
+
+Response on secret-scan refusal (422):
+
+```json
+{
+  "error": "Refusing to create share link: composed output contains potential secrets.",
+  "secrets": [
+    { "rule": "secret_in_prompt", "message": "Potential Anthropic API key detected.", "line": 14 }
+  ]
+}
+```
+
+### Public share
+
+```http
+GET /api/share/compose/{uuid}         (public, throttle:30,1)
+```
+
+Returns the composed payload. `410` on expired, `404` on missing. Increments `access_count` + `last_accessed_at`.
+
+### Delete a share
+
+```http
+DELETE /api/share/compose/{uuid}      (creator only)
+```
+
+Returns `403` for anyone else.
+
+## Eval regression gates (Phase 3)
+
+### Gate config
+
+```http
+GET  /api/skills/{skill}/eval-gate
+PUT  /api/skills/{skill}/eval-gate    (editor+)
+{
+  "enabled": true,
+  "required_suite_ids": [7],
+  "fail_threshold_delta": -5.00,
+  "auto_run_on_save": true,
+  "block_sync": false
+}
+```
+
+### Run gate now
+
+```http
+POST /api/skills/{skill}/eval-gate/run-now   (editor+)
+```
+
+Returns `{ enqueued_run_ids, baseline_info, est_duration_seconds, reason }`.
+
+### Gate status (polled by banner)
+
+```http
+GET /api/skills/{skill}/eval-gate/status
+```
+
+Returns `{ enabled, pending_count, can_sync, runs: [{ run_id, status, overall_score, delta }, …] }`.
+
+### Eval run status (polled during runs)
+
+```http
+GET /api/eval-runs/{eval_run}
+```
+
+Returns the current `SkillEvalRun` row including `status`, `overall_score`, `delta_score`, and `results[]`.
+
+### Sync blocked (409)
+
+When `ProviderSyncService::syncProject` hits an eval gate in block-sync mode:
+
+```http
+POST /api/projects/{project}/sync    → 409
+{
+  "error": "Sync blocked by one or more skill eval gates.",
+  "blocked_skills": [
+    {
+      "skill_id": 42,
+      "skill_slug": "invoice-helper",
+      "skill_name": "Invoice Helper",
+      "last_delta": -8.50,
+      "last_run_id": 118
+    }
+  ]
+}
+```
+
+## Runtime safety (Phase 4)
+
+### Execute with per-run budget
+
+```http
+POST /api/projects/{project}/agents/{agent}/execute     (editor+)
+{
+  "input": { "message": "…" },
+  "token_budget": 50000,
+  "cost_budget_usd": 2.50
+}
+```
+
+### Run detail exposes budget + halt info
+
+`GET /api/runs/{run}` now returns:
+
+```json
+{
+  "status": "halted_guardrail",
+  "halt_reason": "loop_detected",
+  "halt_step_id": 142,
+  "token_budget": 50000,
+  "cost_budget_microcents": 2500000,
+  "total_tokens": 18400,
+  "total_cost_microcents": 87500
+}
+```
+
+`halt_reason` values: `loop_detected`, `turn_cap_exceeded`, `budget_token_exceeded`, `budget_cost_exceeded`.
+
+## Agent social layer (Phase 5)
+
+### Agent profile
+
+```http
+GET /api/agents/{agent}/profile
+```
+
+Returns owner, reputation, domain summary, total invocations, last 10 non-private runs.
+
+### Agent routing
+
+```http
+POST /api/agents/route
+{
+  "question": "Who handles invoice refunds?",
+  "project_id": 14
+}
+```
+
+Returns an ordered list of matches with `score` + human-readable `reasoning`.
+
+### Work feed
+
+```http
+GET /api/work-feed?agent_id=&user_id=&project_id=&per_page=25
+```
+
+Paginated feed of `team` + `org` visible runs scoped to the caller's current org. Only includes `completed` + `halted_guardrail` runs.
+
+### Fork a run
+
+```http
+POST /api/runs/{run}/fork
+```
+
+Clones `input` + `config` into a new pending private run owned by the forker. Linked via `forked_from_run_id`.
+
+### Set run visibility
+
+```http
+PUT /api/runs/{run}/visibility     (creator only)
+{ "visibility": "org" }    // private | team | org
+```
+
+### Project role assignments
+
+```http
+GET    /api/projects/{project}/role-assignments
+POST   /api/projects/{project}/role-assignments          (editor+)
+PUT    /api/projects/{project}/role-assignments/{id}     (editor+)
+DELETE /api/projects/{project}/role-assignments/{id}     (editor+)
+```
+
+Body for create: `{ user_id, role: 'ic' | 'dri' | 'coach', scope?, started_at? }`. `DELETE` sets `ended_at` rather than removing the row.
+
+## Compound learning (Phase 6)
+
+### Capability discovery
+
+```http
+GET  /api/agents/{agent}/capability-suggestions
+POST /api/agents/{agent}/capability-suggestions/dismiss
+{ "suggestion_key": "unused_mcp:42", "expires_in_days": 30 }
+```
+
+### Skill proposals
+
+```http
+GET  /api/skill-proposals[?skill_id=X]
+GET  /api/skill-proposals/{proposal}
+POST /api/skill-proposals/{proposal}/accept   (editor+)
+POST /api/skill-proposals/{proposal}/reject   (editor+)
+{ "suppress_days": 30 }
+```
+
+### Cross-project propagation
+
+```http
+GET  /api/orgs/{organization}/skill-propagations
+POST /api/skill-propagations/{propagation}/accept    (editor+)
+{ "body_override": "Customized for this project…" }
+POST /api/skill-propagations/{propagation}/dismiss   (editor+)
+GET  /api/skills/{skill}/lineage
+```
+


### PR DESCRIPTION
## Summary

Phases 0–6 shipped seven PRs worth of new surfaces (staleness, compose sharing, eval regression gates, runtime safety, agent social layer, compound learning) without docs updates. This PR closes that gap so Phase 7 follow-ups don't start on a stale foundation.

## What's new

Six new guide pages, one per load-bearing cluster:

| Page | Covers |
|---|---|
| `guide/staleness.md` | `tuned_for_model`, reasons (ok / needs_tuning / needs_revalidation / model_deprecated), banner, deprecated model list, revalidation flow |
| `guide/compose-sharing.md` | Model override + `skill_breakdown` offsets, `ComposeShareLink`, secret-scan gate, public `/share/compose/{uuid}` with rate limit |
| `guide/eval-gates.md` | `ScorerInterface` + Keyword/LlmJudge, queued `RunEvalSuiteJob`, gate config, **baseline = most recent run for (suite, model) regardless of version**, 409 sync block, `RegressionGateBanner` + `RegressionDeltaModal` |
| `guide/runtime-safety.md` | Loop detection (xxh128 signature, 6-step window, 3-repeat threshold), org-level turn cap (default 40), per-run token + cost budgets with run > agent > org precedence, halt reasons + notifications |
| `guide/social-layer.md` | Agent ownership + nightly reputation formula (baseline 50 + success-rate − halt-rate − failure-rate ± review-signal), profile page, "Who should I ask?" routing, work feed + fork, IC/DRI/coach project roles |
| `guide/compound-learning.md` | Capability discovery sources + dismissals, pattern extraction heuristic + proposal inbox + accept/reject flow, propagation with model-family compatibility gating + lineage endpoint |

## What's updated

- `docs/changelog.md` — **v1.1.0 block** covering all seven PRs (#549–#555), one paragraph per phase with concrete callouts
- `docs/guide/skill-editor.md` — documents the **banner stack** (StalenessBanner + RegressionGateBanner + InlineGotchaStrip) and flags follow-ups #561/#562
- `docs/guide/linting.md` — three new frontmatter rules (`missing_summary`, `missing_description`, `no_progressive_disclosure`) — now 11 total
- `docs/guide/agents.md` — ownership, reputation, runtime safety, social-layer cross-references + note about 409 blocks on sync when a skill has a failing gate
- `docs/guide/execution.md` — `halted_guardrail` status, per-run budget override via execute API body, run visibility + fork
- `docs/reference/api.md` — ~150 lines appended covering every new endpoint (staleness, compose share public + auth, eval gate config/run-now/status, sync-blocked 409 shape, per-run budget execute body, profile, routing, work-feed, fork, visibility, role assignments, capability suggestions + dismiss, skill proposals, propagations + lineage)

## Sidebar (VitePress config)

- Added Staleness + Compose Sharing under **Building**
- New **Quality & Safety** group — Eval Gates + Runtime Safety
- New **Social Layer & Learning** group — Social Layer + Compound Learning

## Drive-by fix

`docs/guide/schedules.md` had a Vue-template-syntax issue — `{{event.field_name}}` inside a `:::warning` callout was being interpreted as a Vue expression against an undefined `event`, which broke the entire site build. Wrapped the affected phrase in `<span v-pre>` so it renders literally.

## Test plan

- [x] `npm run build` in `docs/` completes cleanly (22s, no errors)
- [x] All new pages render
- [x] All sidebar entries resolve to existing files
- [ ] Manual: navigate to each new page in the dev server and eyeball formatting

## After this merges

Phase 7 follow-ups (issues #556–#562 under milestone #119) become the next unit of work.